### PR TITLE
Add Tide documentation outline

### DIFF
--- a/docs/_outline.md
+++ b/docs/_outline.md
@@ -1,0 +1,73 @@
+# Tide Documentation Outline
+
+Welcome to the future home of Tide docs! This outline sketches the structure for a lively GitHub Pages site powered by MkDocs (or your favorite static site generator). Each bullet below represents a page or section waiting to be filled with deep dives, examples, and cheerful guidance.
+
+## 1. Introduction
+- **What is Tide?**
+  - quick overview
+  - core principles and goals
+- **Why Tide?**
+  - problem space and benefits
+- **Who uses Tide?**
+  - intended audience
+
+## 2. Blueprint of Tide
+- **System Components**
+  - shaping engine
+  - flow orchestration
+  - checkpoint & export
+- **How the Pieces Fit**
+  - step by step walkthrough
+
+## 3. Getting Started
+- **Installation & Setup**
+  - prerequisites
+  - basic install commands
+- **First Tide Run**
+  - simple example
+
+## 4. Shaping Tide
+- **Understanding Shaping**
+  - shaping target
+  - vibe modes
+  - context archive
+- **Shaping Commands & Patterns**
+  - interactive shaping flows
+  - shaping from code snippets
+
+## 5. Using Tide
+- **Common Commands**
+  - launching flows
+  - running triggers
+  - exporting results
+- **Working with Agents**
+  - Flutter integration basics
+  - communication patterns
+
+## 6. Advanced Topics
+- **Custom Triggers & Patterns**
+  - writing your own
+- **Extending with Plugins**
+  - plugin architecture
+  - sharing plugins
+- **Export & Checkpoints**
+  - saving progress
+  - migrating archives
+
+## 7. Glossary
+- key terms & concepts
+  - shaping target
+  - vibe mode
+  - flow stage
+  - blueprint
+  - more to come
+
+## 8. Meta Documentation
+- **How These Docs Work**
+  - site generator & tooling
+  - how to contribute updates
+- **Doc Evolution**
+  - roadmap
+  - community guides
+
+Happy shaping! Feel free to expand or rearrange sections as the project evolves.


### PR DESCRIPTION
## Summary
- set up docs directory for GitHub Pages
- add an outline for the upcoming Tide documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578a1fa6708323b5a85284b1012f16