### PR TITLE
Bootstrapped docs site with MkDocs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements-docs.txt
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+site/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ You can check the project version with:
 ./breathing-willow version
 ```
 
+## Documentation
+
+The project now ships with a lightweight docs site powered by MkDocs.
+Browse the latest version on GitHub Pages or preview locally with:
+
+```bash
+./preview-docs.sh
+```
+
+
 
 ## What to Try Next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to Tide
+
+*Tide* is a playful experiment in shaping AI-powered workflows. It's lightweight, easy to remix, and built for folks who love tinkering with new ideas.
+
+This site is just getting started. Check out the [outline](_outline.md) to see where the docs are headed, and stay tuned as we add more guides and examples.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: Tide Docs
+site_description: Documentation for the Tide project
+site_url: https://example.com
+nav:
+  - Home: index.md
+  - Outline: _outline.md
+theme:
+  name: material

--- a/preview-docs.sh
+++ b/preview-docs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Install docs dependencies and serve the site locally
+pip install -r requirements-docs.txt
+mkdocs serve

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.6
+mkdocs-material>=9.5


### PR DESCRIPTION
## Summary
- add MkDocs config and index page
- deploy site via GitHub Actions
- helper script to preview docs
- document the new docs site in README

## Testing
- `pytest -q`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68578a9e249883238a7432ab8cd364a4