### PR TITLE
Add missing 'What is Tide' page and nav entry

### DIFF
--- a/docs/what-is-tide.md
+++ b/docs/what-is-tide.md
@@ -1,0 +1,3 @@
+# What is Tide?
+
+Tide is an experimental framework for shaping AI-powered workflows. It focuses on lightweight building blocks that can be remixed to automate tasks and prototype new agent flows. The project is still early, but aims to make it easy for contributors to script, refine, and share playful experiments.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: Documentation for the Tide project
 site_url: https://example.com
 nav:
   - Home: index.md
+  - What is Tide?: what-is-tide.md
   - Outline: _outline.md
 theme:
   name: material


### PR DESCRIPTION
## Summary
- add a `docs/what-is-tide.md` page
- include that page in `mkdocs.yml`

## Testing
- `./preview-docs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68578b8b2f508323a9219967b2acf602