### PR TITLE
Add how-to-use tide docs page

### DIFF
--- a/docs/how-to-use-tide.md
+++ b/docs/how-to-use-tide.md
@@ -1,0 +1,13 @@
+# How to Use Tide
+
+*Tide* is an evolving platform for shaping AI-driven workflows. It brings together chat-based interactions, code snippets, and a vibe-first mindset so you can experiment with automation in a playful way.
+
+Using Tide is simple. Here are three patterns to get you started:
+
+1. **Vibe Coding** – you might say, "`tide run vibe-code`" to kick off a session where you tinker with code and see how the system adapts. It's a casual way to try ideas quickly.
+2. **Shaping Conversations** – you might say, "`tide flow shape-this-convo`" when you want to steer the chat in a certain direction. Tide listens and adjusts the context as you go.
+3. **Managing Agents** – you might say, "`tide agent status`" or "`tide agent tune`" to check in on your agents or tweak their behavior. Tide gives you the tools to keep everything humming.
+
+Behind the scenes, Tide keeps track of a *shaping target*. That's the goal you're aiming for, and Tide surfaces it so you always know where you're headed. The more you interact, the clearer the target becomes.
+
+Have fun! Every command shapes Tide a bit more, so you're constantly refining the experience as you use it.


### PR DESCRIPTION
## Summary
- add lively page on how to use Tide

## Testing
- `pip install -r requirements-docs.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68578c06a5d8832383d95a6e337cf45d