### PR TITLE
Add fun glossary page

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,18 @@
+# Glossary (Fun Terms & Concepts)
+
+Here's a lighthearted list of terms that pop up around Tide. Keep it handy when you want to follow the chatter without missing a beat.
+
+- **Shaping Target** – the goal you're nudging the conversation toward. It clarifies as you interact and helps steer the flow.
+- **Checkpoint** – a quick save of your progress so you can return to a moment in the experiment whenever you like.
+- **Context Archive** – the running log of chats and actions. Tide tucks it away for reference or export later on.
+- **Vibe Coding** – a playful approach to scripting. You riff on ideas and let the vibe guide your code tweaks.
+- **Agent Class** – a set of behaviors that defines how an agent acts. Think of it as a personality template.
+- **Blueprint** – a reusable plan for assembling flows. It lays out the pieces so you can spin up new experiments fast.
+- **Flutter** – a tiny burst of messages that keeps the conversation lively and responsive.
+- **Pure Vibe Mode** – when you drop the rules and follow intuition entirely. Anything goes as long as the energy feels right.
+- **Flow Stage** – a step in the overall process, like shaping, coding, or publishing. Each stage builds on the last.
+- **Trigger** – an event or prompt that kicks off a fresh action or branch in the flow.
+- **Quick Save** – a mini checkpoint for when you want to test something risky without losing your spot.
+- **Vibe Check** – a pause to sense how things are going. Adjust the flow if it feels off so everyone stays in sync.
+
+Enjoy the journey! These definitions should make it easier to dive into the rest of the docs with confidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,5 +5,6 @@ nav:
   - Home: index.md
   - What is Tide?: what-is-tide.md
   - Outline: _outline.md
+  - Glossary: glossary.md
 theme:
   name: material


### PR DESCRIPTION
## Summary
- add a light glossary of Tide terms
- add the new page to the MkDocs navigation

## Testing
- `pip install -r requirements-docs.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68578dc07e548323b9bd1941b311e569