### PR TITLE
Add CLI command to preview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,20 @@ You can check the project version with:
 ## Documentation
 
 The project now ships with a lightweight docs site powered by MkDocs.
-Browse the latest version on GitHub Pages or preview locally with:
+Install the docs requirements once with:
 
 ```bash
-./preview-docs.sh
+pip install -r requirements-docs.txt
 ```
 
+Then preview the docs locally with our CLI:
 
+```bash
+breathing-willow docs
+```
 
+This command runs `mkdocs serve` with live reload and prints the local URL
+(`http://127.0.0.1:8000`) so you can open it in your browser.
 ## What to Try Next
 
 - Sketch your own agent by adding a simple Python script in `agents/` (directory coming soon).

--- a/cli/breathing_willow.py
+++ b/cli/breathing_willow.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 from datetime import datetime, timezone
+import subprocess
 
 
 def log_prompt(title: str, task_link: str, commit_link: str | None = None) -> None:
@@ -62,6 +63,16 @@ def main(argv=None):
     )
     step_parser.add_argument("note", help="short note for the step")
 
+    docs_parser = subparsers.add_parser(
+        "docs", help="build and preview the documentation"
+    )
+    docs_parser.add_argument(
+        "--host", default="127.0.0.1", help="host to bind (default: 127.0.0.1)"
+    )
+    docs_parser.add_argument(
+        "--port", default="8000", help="port to serve on (default: 8000)"
+    )
+
     args = parser.parse_args(argv)
     version = get_version()
 
@@ -73,6 +84,13 @@ def main(argv=None):
         log_prompt(args.title, args.link, args.commit)
     elif args.command == "vc-step":
         mark_vc_step(args.note)
+    elif args.command == "docs":
+        host = args.host
+        port = args.port
+        url = f"http://{host}:{port}"
+        print(f"Serving docs at {url} (live reload). Press Ctrl+C to stop.")
+        cmd = ["mkdocs", "serve", "--dev-addr", f"{host}:{port}"]
+        subprocess.run(cmd, check=True)
 
 
 if __name__ == "__main__":

--- a/preview-docs.sh
+++ b/preview-docs.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Install docs dependencies and serve the site locally
 pip install -r requirements-docs.txt
-mkdocs serve
+breathing-willow docs "$@"


### PR DESCRIPTION
## Summary
- add `docs` CLI command that runs `mkdocs serve`
- clarify doc preview instructions in README
- update helper script to use the CLI command

## Testing
- `pip install -r requirements-docs.txt`
- `python cli/breathing_willow.py docs &> /tmp/docs.log &`
- `mkdocs build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857943e0b5083239b8b905ceddf21aa