### PR TITLE
Add checkpointing docs page

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -1,0 +1,33 @@
+# Checkpointing in Tide
+
+A **checkpoint** is Tide's way of saving your place in an experiment. It captures the current conversation, code snippets, and shaping target so you can jump back to that moment later.
+
+## When and Why to Use a Checkpoint
+
+Checkpointing is handy whenever you reach a milestone or want to preserve your progress before trying something risky. By saving a checkpoint, you ensure you can restore the same context if your next steps don't work out.
+
+## How to Trigger a Checkpoint
+
+You can trigger checkpoints directly from the command line. Here are two quick examples:
+
+```bash
+# save a checkpoint with a custom label
+$ tide checkpoint save "initial-shape"
+
+# list checkpoints and restore one
+$ tide checkpoint list
+$ tide checkpoint load "initial-shape"
+```
+
+## Why Checkpointing Matters
+
+Flows evolve quickly, and it's easy to lose track of how you got to a certain state. Checkpoints keep your experiments stable, giving you a reliable way to rewind or branch out without starting over.
+
+## Good Moments to Checkpoint
+
+- right after you shape a new goal
+- before testing a major code change
+- when a conversation delivers key insight
+- anytime you want a safe point to return to
+
+With regular checkpoints, you can explore freely and still keep your flow under control.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Home: index.md
   - What is Tide?: what-is-tide.md
   - Outline: _outline.md
+  - Checkpointing: checkpointing.md
   - Glossary: glossary.md
 theme:
   name: material


### PR DESCRIPTION
## Summary
- explain how checkpointing works in Tide
- show how to trigger checkpoints from the CLI
- include new page in mkdocs navigation

## Testing
- `pip install -r requirements-docs.txt`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_685794cf253c8323b3373f9eeba7e268