### PR TITLE
Implement update-net CLI and improved visualization

### DIFF
--- a/breathing_willow/willow_viz.py
+++ b/breathing_willow/willow_viz.py
@@ -147,8 +147,10 @@ class WillowGrowth:
                 if data.get('shaped'):
                     label = data.get('sentence', nid)
                 else:
-                    label = f"{nid}\n{','.join(data.get('terms', [])[:5])}"
-                net.add_node(nid, label='', title=label)
+                    label = ",".join(data.get('terms', [])[:5])
+                # keep the uid in the tooltip for reference
+                title = nid
+                net.add_node(nid, label=label, title=title)
             for u, v, d in self.graph.edges(data=True):
                 net.add_edge(u, v, value=d.get('weight', 1))
             if len(self.graph.nodes) == 0:

--- a/breathing_willow_cli/breathing_willow.py
+++ b/breathing_willow_cli/breathing_willow.py
@@ -2,6 +2,9 @@ import argparse
 from pathlib import Path
 from datetime import datetime, timezone
 import subprocess
+from typing import Sequence
+
+from breathing_willow.willow_viz import WillowGrowth
 
 
 def log_prompt(title: str, task_link: str, commit_link: str | None = None) -> None:
@@ -73,6 +76,26 @@ def main(argv=None):
         "--port", default="8000", help="port to serve on (default: 8000)"
     )
 
+    update_parser = subparsers.add_parser(
+        "update-net", help="add a document to the graph and render"
+    )
+    update_parser.add_argument(
+        "-f",
+        "--file",
+        required=True,
+        help="path to the document to ingest",
+    )
+    update_parser.add_argument(
+        "--visual-archive",
+        required=True,
+        help="path to write the visualization HTML",
+    )
+    update_parser.add_argument(
+        "--graph",
+        default="willow_growth_v5.json",
+        help="path to persistent graph (default: willow_growth_v5.json)",
+    )
+
     args = parser.parse_args(argv)
     version = get_version()
 
@@ -91,7 +114,12 @@ def main(argv=None):
         print(f"Serving docs at {url} (live reload). Press Ctrl+C to stop.")
         cmd = ["mkdocs", "serve", "--dev-addr", f"{host}:{port}"]
         subprocess.run(cmd, check=True)
+    elif args.command == "update-net":
+        wg = WillowGrowth(graph_path=args.graph)
+        wg.submit_document(args.file)
+        wg.visualize(args.visual_archive)
 
 
 if __name__ == "__main__":
     main()
+

--- a/tests/test_update_net.py
+++ b/tests/test_update_net.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import breathing_willow.willow_viz as willow_viz
+
+# Avoid NLTK downloads during tests
+willow_viz.word_tokenize = None
+
+from breathing_willow.willow_viz import WillowGrowth
+
+
+def create_initial_graph(tmp_path: Path) -> Path:
+    gpath = tmp_path / "graph.json"
+    wg = WillowGrowth(graph_path=gpath)
+    doc1 = tmp_path / "doc1.txt"
+    doc1.write_text("alpha beta gamma")
+    wg.submit_document(doc1)
+    return gpath
+
+
+def test_update_net(tmp_path: Path):
+    graph_path = create_initial_graph(tmp_path)
+    before_nodes = set(WillowGrowth(graph_path=graph_path).graph.nodes)
+
+    doc2 = tmp_path / "doc2.txt"
+    doc2.write_text("alpha delta")
+    output_html = tmp_path / "out.html"
+
+    from breathing_willow_cli.breathing_willow import main as cli_main
+
+    argv = [
+        "update-net",
+        "--graph",
+        str(graph_path),
+        "--visual-archive",
+        str(output_html),
+        "-f",
+        str(doc2),
+    ]
+    cli_main(argv)
+
+    wg = WillowGrowth(graph_path=graph_path)
+    after_nodes = set(wg.graph.nodes)
+
+    # graph should grow by one node
+    assert len(after_nodes) == len(before_nodes) + 1
+
+    new_nodes = after_nodes - before_nodes
+    assert len(new_nodes) == 1
+    new_node = next(iter(new_nodes))
+
+    # new node should have at least one edge (shared term 'alpha')
+    assert len(list(wg.graph.edges(new_node))) >= 1
+
+    # visualization written
+    assert output_html.exists()


### PR DESCRIPTION
## Summary
- add `update-net` command to breathing-willow CLI
- show keywords or shaped sentence as node label in visualization
- provide functional pytest test for incremental graph update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b99a311c8323916253a1724384c0