### PR TITLE
Enhance shaping log with points

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ breathing-willow docs
 
 This command runs `mkdocs serve` with live reload and prints the local URL
 (`http://127.0.0.1:8000`) so you can open it in your browser.
+
+## Shaping Log and Points
+
+Running `breathing-willow update-net -f <file>` ingests a document into the
+word network. Each run prepends an entry to the shaping log located at
+`/l/obs-chaotic/willow-shaping.md` (or the path from the `WILLOW_SHAPING_LOG`
+environment variable). The entry records the file path, any UUIDs found, a tag
+cloud, and a points value. Points accumulate across runs and increase when new
+unique words appear. The network visualization grows as more unique terms are
+added, showing word nodes with a count label.
 ## What to Try Next
 
 - Sketch your own agent by adding a simple Python script in `agents/` (directory coming soon).

--- a/breathing_willow/willow_viz.py
+++ b/breathing_willow/willow_viz.py
@@ -155,16 +155,25 @@ class WillowGrowth:
                   }
                 }
             """)
-            for nid, data in self.graph.nodes(data=True):
-                if data.get('shaped'):
-                    label = data.get('sentence', nid)
-                else:
-                    label = ",".join(data.get('terms', [])[:5])
-                # keep the uid in the tooltip for reference
-                title = nid
-                net.add_node(nid, label=label, title=title)
-            for u, v, d in self.graph.edges(data=True):
-                net.add_edge(u, v, value=d.get('weight', 1))
+            word_counts = {}
+            for _, data in self.graph.nodes(data=True):
+                for w in data.get('terms', []):
+                    word_counts[w] = word_counts.get(w, 0) + 1
+
+            word_edges = {}
+            for _, data in self.graph.nodes(data=True):
+                terms = data.get('terms', [])
+                for i in range(len(terms)):
+                    for j in range(i + 1, len(terms)):
+                        pair = tuple(sorted((terms[i], terms[j])))
+                        word_edges[pair] = word_edges.get(pair, 0) + 1
+
+            for word, count in word_counts.items():
+                net.add_node(word, label=f"{word} ({count})", value=count)
+
+            for (a, b), weight in word_edges.items():
+                net.add_edge(a, b, value=weight)
+
             if len(self.graph.nodes) == 0:
                 print("⚠️ Graph empty — nothing to render.")
             else:

--- a/tests/test_shaping_log.py
+++ b/tests/test_shaping_log.py
@@ -29,10 +29,15 @@ def test_update_net_shaping_log(tmp_path, monkeypatch):
     assert "shape.txt" in first
     assert "123e4567-e89b-12d3-a456-426614174000" in first
     assert "Tag Cloud:" in first
-    assert first.startswith("## Shaping Log")
+    header = first.splitlines()[0]
+    assert re.search(r"## Shaping Log \u2014 .* \u2014 \d+ pts", header)
+    assert "**Points:" in first
     assert first.strip().endswith("---")
 
     cli_main(argv)
     second = log_file.read_text()
     assert second.count("## Shaping Log") == 2
     assert second.endswith(first)
+    pts_first = int(re.search(r"(\d+) pts", first).group(1))
+    pts_second = int(re.search(r"(\d+) pts", second).group(1))
+    assert pts_second > pts_first


### PR DESCRIPTION
## Summary
- compute shaping points in `append_shaping_log`
- show total points in shaping log entries
- update visualization to display a word network with counts
- document shaping log usage and points in README
- adjust shaping log tests for new format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859011e0c3c8323b14bda5146c60e66