### PR TITLE
Fix term loop in visualization

### DIFF
--- a/breathing_willow/willow_viz.py
+++ b/breathing_willow/willow_viz.py
@@ -167,7 +167,7 @@ class WillowGrowth:
 
             word_edges = {}
             for _, data in self.graph.nodes(data=True):
-      
+                terms = data.get('terms', [])
                 for i in range(len(terms)):
                     for j in range(i + 1, len(terms)):
                         pair = tuple(sorted((terms[i], terms[j])))


### PR DESCRIPTION
## Summary
- fix a NameError in `visualize`
- iterate over node terms when creating word edges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590f80571883238a431129764ff7e5