### PR TITLE
Connect sense command to conceptual diff

### DIFF
--- a/breathing_willow_cli/breathing_willow.py
+++ b/breathing_willow_cli/breathing_willow.py
@@ -145,8 +145,11 @@ def main(argv=None):
     subparsers = parser.add_subparsers(dest="command")
 
     sense_parser = subparsers.add_parser("sense", help="sense for pulse (diff)")
-    sense_parser.add_argument("--diff", required=False, help="diff",
-                              type=bool, default=False)
+    sense_parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="export conceptual diff report",
+    )
 
     log_parser = subparsers.add_parser("log-prompt", help="log a codex prompt")
     log_parser.add_argument("--title", required=True, help="prompt title")
@@ -200,7 +203,11 @@ def main(argv=None):
         return
 
     if args.command == "sense":
-        print('sense')
+        if args.diff:
+            report = diff.export_diff("/field")
+            Path("/field/field-update.md").write_text(report)
+        else:
+            print("sense")
     elif args.command == "log-prompt":
         log_prompt(args.title, args.link, args.commit)
     elif args.command == "vc-step":

--- a/tests/test_sense_cli.py
+++ b/tests/test_sense_cli.py
@@ -1,0 +1,29 @@
+import pathlib
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breathing_willow_cli.breathing_willow import main as cli_main
+from w_cli import diff
+
+
+def test_sense_diff_writes_update(monkeypatch, tmp_path):
+    calls = {}
+    def fake_export(root: str, window: str = '24h', back: str | None = None) -> str:
+        calls['root'] = root
+        return 'log data'
+    monkeypatch.setattr(diff, 'export_diff', fake_export)
+
+    out_file = tmp_path / 'field-update.md'
+    orig_write = Path.write_text
+    def fake_write(self, text, *a, **kw):
+        if str(self) == '/field/field-update.md':
+            out_file.write_text(text)
+        else:
+            orig_write(self, text, *a, **kw)
+    monkeypatch.setattr(Path, 'write_text', fake_write)
+
+    cli_main(['sense', '--diff'])
+
+    assert calls['root'] == '/field'
+    assert out_file.read_text() == 'log data'


### PR DESCRIPTION
## Summary
- expose `--diff` as a flag instead of accepting a value
- wire `sense --diff` to `export_diff` and write the report to `/field/field-update.md`
- add regression test for new `sense` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f8defa6083239e7699b48cf08bcb