### PR TITLE
Add export kernel scaffold

### DIFF
--- a/breathing_willow/export_kernel.py
+++ b/breathing_willow/export_kernel.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Export kernel for converting ChatGPT exports to Markdown.
+
+This module defines the scaffold for parsing zipped ChatGPT exports into
+Markdown files optimized for rhythm-aware shaping workflows. All
+functionality here is placeholder-only. Future prompts will gradually
+replace the print statements with real logic.
+"""
+
+from pathlib import Path
+
+
+class ChatExportArchiver:
+    """Handles overall process: unpacking .zip, iterating files, coordinating pipeline."""
+
+    def __init__(self, zip_path: Path, output_dir: Path) -> None:
+        self.zip_path = zip_path
+        self.output_dir = output_dir
+        print(f"ChatExportArchiver initialized with {zip_path} -> {output_dir}")
+
+    def run(self) -> None:
+        """Simulate running the export pipeline."""
+        print("Unpacking zip...")
+        print("Found 6 conversations...")
+        print(f"Writing to {self.output_dir / 'convo_001.md'}")
+
+
+class ThreadParser:
+    """Parses individual conversation files into structured Markdown with user/agent turns."""
+
+    def __init__(self, raw_thread: dict | str) -> None:
+        self.raw_thread = raw_thread
+        print("ThreadParser initialized")
+
+    def parse(self) -> str:
+        """Return placeholder parsed Markdown."""
+        print("Parsing thread...")
+        return "# parsed markdown"
+
+
+class MemoryEchoInserter:
+    """Inserts semantic breaks + memory echoes into raw markdown every ~3k tokens."""
+
+    def __init__(self, md_text: str, token_limit: int = 3000) -> None:
+        self.md_text = md_text
+        self.token_limit = token_limit
+        print(f"MemoryEchoInserter initialized with token_limit={token_limit}")
+
+    def insert_memory_echoes(self) -> str:
+        """Return markdown text with placeholder memory echoes."""
+        print("Inserting memory echoes...")
+        return self.md_text
+
+
+class MarkdownExporter:
+    """Handles writing the final .md output to disk, ensuring scroll-readability and UTF-8."""
+
+    def __init__(self, parsed_text: str, output_path: Path) -> None:
+        self.parsed_text = parsed_text
+        self.output_path = output_path
+        print(f"MarkdownExporter initialized for {output_path}")
+
+    def write(self) -> None:
+        """Simulate writing markdown to disk."""
+        print(f"Writing markdown to {self.output_path}")
+
+
+def main() -> None:
+    """Entry point for running the export kernel."""
+    zip_path = Path("chatgpt_export.zip")
+    output_dir = Path("field/chatgpt-export/2025-07-01")
+    archiver = ChatExportArchiver(zip_path, output_dir)
+    archiver.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add breathing_willow/export_kernel.py placeholder
- define ChatExportArchiver, ThreadParser, MemoryEchoInserter, and MarkdownExporter
- include a simple `main()` runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686417ecbe8c8323a190ace672477b82