### PR TITLE
Implement memory echo insertion

### DIFF
--- a/breathing_willow/export_kernel.py
+++ b/breathing_willow/export_kernel.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import json
 import tempfile
 import zipfile
+import re
+from collections import Counter
 
 
 class ChatExportArchiver:
@@ -84,9 +86,136 @@ class MemoryEchoInserter:
         print(f"MemoryEchoInserter initialized with token_limit={token_limit}")
 
     def insert_memory_echoes(self) -> str:
-        """Return markdown text with placeholder memory echoes."""
+        """Return markdown text with inserted folding markers and memory cues."""
         print("Inserting memory echoes...")
-        return self.md_text
+
+        segments = self._segment_text()
+        if len(segments) <= 1:
+            return self.md_text
+
+        output_parts = [segments[0]]
+        prev_segment = segments[0]
+        for idx, segment in enumerate(segments[1:], 1):
+            cue = self._make_cue(prev_segment)
+            print(f"Cue for segment {idx}: {cue}")
+            fold = f"<!-- fold:start -->\n\N{CLOCKWISE OPEN CIRCLE ARROW} memory: {cue}\n<!-- fold:end -->\n"
+            print("Inserting fold marker")
+            output_parts.append(fold)
+            output_parts.append(segment)
+            prev_segment = segment
+        return "".join(output_parts)
+
+    # simple english stop words
+    _STOP_WORDS = {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "but",
+        "if",
+        "while",
+        "of",
+        "at",
+        "by",
+        "for",
+        "with",
+        "about",
+        "against",
+        "between",
+        "into",
+        "through",
+        "during",
+        "before",
+        "after",
+        "to",
+        "from",
+        "in",
+        "out",
+        "on",
+        "off",
+        "over",
+        "under",
+        "again",
+        "further",
+        "then",
+        "once",
+        "here",
+        "there",
+        "all",
+        "any",
+        "both",
+        "each",
+        "few",
+        "more",
+        "most",
+        "other",
+        "some",
+        "such",
+        "no",
+        "nor",
+        "not",
+        "only",
+        "own",
+        "same",
+        "so",
+        "than",
+        "too",
+        "very",
+        "can",
+        "will",
+        "just",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+    }
+
+    def _segment_text(self) -> list[str]:
+        """Split markdown text into ~token_limit chunks preserving order."""
+        print("Segmenting text...")
+        token_re = re.compile(r"\b\w+\b")
+        segments: list[str] = []
+        start = 0
+        count = 0
+        for match in token_re.finditer(self.md_text):
+            count += 1
+            if count >= self.token_limit:
+                end = self.md_text.find("\n", match.end())
+                if end == -1:
+                    end = match.end()
+                else:
+                    end += 1
+                segment = self.md_text[start:end]
+                print(f"Created segment with {count} tokens")
+                segments.append(segment)
+                start = end
+                count = 0
+        segments.append(self.md_text[start:])
+        return segments
+
+    def _make_cue(self, text: str) -> str:
+        """Generate a short memory cue from ``text``."""
+        words = re.findall(r"[A-Za-z]+", text.lower())
+        filtered = [w for w in words if w not in self._STOP_WORDS]
+        if not filtered:
+            filtered = words
+        counts = Counter(filtered)
+        top_words = [w for w, _ in counts.most_common(7)]
+        if len(top_words) < 3:
+            extras = [w for w in words if w not in top_words]
+            top_words.extend(extras[: 3 - len(top_words)])
+        cue = " ".join(top_words[:7])
+        return cue
 
 
 class MarkdownExporter:


### PR DESCRIPTION
## Summary
- implement `MemoryEchoInserter` for breaking markdown into ~3k token segments
- insert folding markers with keyword-based memory cues
- add minimal stop word list and segmentation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642394240c8323939ed827bc562715