### PR TITLE
Switch export kernel to HTML

### DIFF
--- a/breathing_willow_cli/breathing_willow.py
+++ b/breathing_willow_cli/breathing_willow.py
@@ -217,9 +217,8 @@ def main(argv=None):
 
     if args.command == "history":
         from breathing_willow.export_kernel import ChatExportArchiver
-        from datetime import datetime 
-        from pathlib import Path
-        from os.path import join 
+        from datetime import datetime
+        from os.path import join
         now = datetime.now()
         fpo = Path(join('/l/gds/chatgpt-exports', now.strftime('%Y-%m-%d')))
         fpi = Path(args.file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "gensim",
     "pyvis",
     "scikit-learn",
+    "pytz",
 ]
 
 [project.scripts]

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -52,9 +52,9 @@ def test_archiver_conversations_json(tmp_path: Path):
     arch = ChatExportArchiver(zip_path, out_dir)
     arch.run()
 
-    files = list(out_dir.glob("*.md"))
+    files = list(out_dir.glob("*.html"))
     assert len(files) == 1
     text = files[0].read_text()
-    assert "## zero:" in text
-    assert "## tide:" in text
+    assert "user-turn" in text
+    assert "assistant-turn" in text
 

--- a/tests/test_thread_parser.py
+++ b/tests/test_thread_parser.py
@@ -16,11 +16,11 @@ def test_simple_thread_parsing():
             {"author": "assistant", "content": "hi"},
         ],
     }
-    md = ThreadParser(thread).parse()
+    html = ThreadParser(thread, export_id="exp").parse()
     expected_date = datetime.fromtimestamp(ts).date().isoformat()
-    assert f"date: {expected_date}" in md
-    assert "## zero:" in md
-    assert "## tide:" in md
+    assert f"<div class=\"date\">{expected_date}</div>" in html
+    assert "<div class=\"user-turn\">" in html
+    assert "<div class=\"assistant-turn\">" in html
 
 
 def test_skip_malformed_entries():
@@ -29,9 +29,8 @@ def test_skip_malformed_entries():
         {"content": "no author"},
         {"author": "user", "content": "good"},
     ]
-    md = ThreadParser(thread).parse()
-    lines = [l for l in md.splitlines() if l.startswith("##")]
-    assert lines == ["## zero:"]
+    html = ThreadParser(thread, export_id="exp").parse()
+    assert html.count("user-turn") == 1
 
 
 def test_json_string_input():
@@ -39,6 +38,6 @@ def test_json_string_input():
         {"author": "user", "content": "x"},
         {"author": "assistant", "content": "y"},
     ])
-    md = ThreadParser(data).parse()
-    assert "## zero:" in md and "## tide:" in md
+    html = ThreadParser(data, export_id="exp").parse()
+    assert "user-turn" in html and "assistant-turn" in html
 


### PR DESCRIPTION
## Summary
- update `ChatExportArchiver` and `ThreadParser` to export HTML
- include export metadata, start and end datetimes
- fix CLI `Path` scoping issue
- adjust tests for HTML output
- add `pytz` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cb9262d88323801cd4c209fa6b2c