### PR TITLE
Fix kernel index generation

### DIFF
--- a/breathing_willow/export_kernel.py
+++ b/breathing_willow/export_kernel.py
@@ -98,6 +98,10 @@ class ChatExportArchiver:
                 except Exception as exc:
                     print(f"Failed to write {dest_path}: {exc}")
 
+        # after all scrolls are written, generate the root index
+        # this index is the archive trailhead for browsing
+        KernelIndexPage().run(self.output_dir)
+
 
 class ThreadParser:
     """Parses individual conversation files into structured HTML with user/agent turns."""

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -53,8 +53,35 @@ def test_archiver_conversations_json(tmp_path: Path):
     arch.run()
 
     files = list(out_dir.glob("*.html"))
-    assert len(files) == 1
-    text = files[0].read_text()
+    assert (out_dir / "001-conversation.html").exists()
+    assert (out_dir / "index.html").exists()
+    text = (out_dir / "001-conversation.html").read_text()
     assert "user-turn" in text
     assert "assistant-turn" in text
+
+
+def test_archiver_index_page(tmp_path: Path):
+    convo1 = make_conversation()
+    convo2 = make_conversation()
+    convo2["mapping"]["abc"]["message"]["content"]["parts"] = ["second thread"]
+    convo2["mapping"]["abc"]["message"]["create_time"] = 1700001000
+    convos = [convo1, convo2]
+    convo_path = tmp_path / "conversations.json"
+    convo_path.write_text(json.dumps(convos))
+
+    zip_path = tmp_path / "exp.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(convo_path, arcname="conversations.json")
+
+    out_dir = tmp_path / "out"
+    arch = ChatExportArchiver(zip_path, out_dir)
+    arch.run()
+
+    index_file = out_dir / "index.html"
+    assert index_file.exists()
+    index_text = index_file.read_text()
+    assert "001-conversation.html" in index_text
+    assert "002-conversation.html" in index_text
+    assert "hello" in index_text
+    assert "second thread" in index_text
 


### PR DESCRIPTION
## Summary
- write an archive index after exporting conversations
- adjust tests for new index page
- verify the index links to scrolls and shows snippet previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a65de1cc8323b88304638ca12707