### PR TITLE
Implement snip-file CLI function

### DIFF
--- a/breathing_willow_cli/breathing_willow.py
+++ b/breathing_willow_cli/breathing_willow.py
@@ -216,6 +216,16 @@ def main(argv=None):
         help="directory to save version snapshots (default: alongside file)",
     )
 
+    snip_parser = subparsers.add_parser(
+        "snip-file", help="truncate file to last practical tokens"
+    )
+    snip_parser.add_argument(
+        "-f",
+        "--file",
+        required=True,
+        help="path to markdown file to snip",
+    )
+
     args = parser.parse_args(argv)
     version = get_version()
 
@@ -277,32 +287,24 @@ def main(argv=None):
         clusters = wg.cluster_terms()
         append_shaping_log(src, clusters)
     elif args.command == "snip-file":
-        # TODO - implement 
-        # here, 
-################################################################################
-# BEGIN PROMPT
-"""
-prompt for codex
-tranquil-mosswood
-14551f77-583a-4174-b10e-d05181f15d2d
+        from breathing_willow import snip_file as sf
+        import tiktoken
 
-you'll implement the following: when I run `willow snip-file -f /field/prompt.md`, 
-function snip_file_to_last_tokens will be used as below: 
+        fp = Path(args.file)
+        if not fp.exists():
+            raise SystemExit(f"file not found: {fp}")
 
-```snippet1
-from breathing_willow import snip_file as sf
-In [4]: sf.snip_file_to_last_tokens('/field/prompt.md', context_scope='practical', 
-    aggressive=True); # devstripprompt
-```
-... fully integrate this into the cli. make sure to print out what his
-happening. 
+        enc = tiktoken.encoding_for_model("gpt-4")
+        before_text = fp.read_text(encoding="utf-8")
+        before_tokens = len(enc.encode(before_text))
+        print(f"File '{fp}' has {before_tokens} tokens before snipping.")
 
-importantly, start by telling user how many tokens there are, then after running
-snip_file_to_last_tokens, re-evalute fresh to count tokens. 
+        print("Snipping file to last practical context...")
+        sf.snip_file_to_last_tokens(str(fp), context_scope="practical", aggressive=True)
 
-"""
-# END PROMPT
-################################################################################
+        after_text = fp.read_text(encoding="utf-8")
+        after_tokens = len(enc.encode(after_text))
+        print(f"File '{fp}' now has {after_tokens} tokens after snipping.")
 if __name__ == "__main__":
     main()
 

--- a/tests/test_snip_file_cli.py
+++ b/tests/test_snip_file_cli.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breathing_willow_cli.breathing_willow import main as cli_main
+
+
+def test_snip_file_cli(monkeypatch, tmp_path, capsys):
+    test_file = tmp_path / "t.md"
+    test_file.write_text("a b c d e")
+
+    class FakeEnc:
+        def encode(self, text):
+            return text.split()
+        def decode(self, tokens):
+            return " ".join(tokens)
+
+    fake_tiktoken = types.SimpleNamespace(encoding_for_model=lambda m: FakeEnc())
+    monkeypatch.setitem(sys.modules, "tiktoken", fake_tiktoken)
+
+    from breathing_willow import snip_file as sf
+
+    def fake_snip(fp, context_scope="practical", aggressive=False):
+        p = Path(fp)
+        tokens = FakeEnc().encode(p.read_text())
+        new_text = FakeEnc().decode(tokens[-2:])
+        if aggressive:
+            p.write_text(new_text)
+        return new_text
+
+    monkeypatch.setattr(sf, "snip_file_to_last_tokens", fake_snip)
+
+    cli_main(["snip-file", "-f", str(test_file)])
+
+    out = capsys.readouterr().out
+    assert "has 5 tokens" in out
+    assert "now has 2 tokens" in out
+    assert test_file.read_text() == "d e"


### PR DESCRIPTION
## Summary
- add `snip-file` command to breathing-willow CLI
- implement logic to truncate files to last practical tokens
- print token counts before and after snipping
- add test coverage for the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dad7d9ef483238c415c190bd24e3b