### PR TITLE
Implement Stage 3 prompt comparison packaging

### DIFF
--- a/breathing_willow/assets/prompt-compare-s3.jinja2
+++ b/breathing_willow/assets/prompt-compare-s3.jinja2
@@ -1,0 +1,21 @@
+# prompt
+
+{{ text_prompt }}
+
+# output
+
+`<output will go here>`
+
+# values
+
+{{ value_statements }}
+
+# fuzzy objective
+
+{{ fuzzy_objective }}
+
+# evaluation
+
+user: run prompt in a sandbox LLM, then paste output back here (i.e. `<output will go here>`). then, run this entire context to get my evaluation of the prompt.
+
+Write an LLM prompt that uses the values and objective above to evaluate the output text.

--- a/breathing_willow/watchful_fog_dev_kernel.py
+++ b/breathing_willow/watchful_fog_dev_kernel.py
@@ -32,3 +32,33 @@ def generate_surfacing(fp_values='/field/values.md', i='',
         'cname':cname, 'uuid':i, 
     })
 
+
+
+def render_compare_prompt(text_prompt: str, fp_values: str = '/field/values.md',
+                           fp_objective: str = '/field/objective.md') -> str:
+    """Render a Stage 3 comparison prompt container.
+
+    Parameters
+    ----------
+    text_prompt : str
+        The surfacing prompt text to package.
+    fp_values : str
+        Path to the values file.
+    fp_objective : str
+        Path to the fuzzy objective file.
+
+    Returns
+    -------
+    str
+        Rendered markdown text for comparison.
+    """
+    tmpl = Template(load_asset('prompt-compare-s3', ext='jinja2'))
+    with open(fp_values, 'r') as f:
+        values = f.read()
+    with open(fp_objective, 'r') as f:
+        objective = f.read()
+    return tmpl.render({
+        'text_prompt': text_prompt,
+        'value_statements': values,
+        'fuzzy_objective': objective,
+    })


### PR DESCRIPTION
## Summary
- add Stage 3 template asset for packaging surfacings
- implement `render_compare_prompt` helper
- extend CLI with `--step3-package-compare` and `--keys`
- write comparison files to `/field/compare` and update snip-file handling

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e14b016048323b34196c0eff820cd