### PR TITLE
Add publish-field subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ utility:
 - `vc-step` – record a short version-control loop note.
 - `docs` – build and preview this documentation site with live reload.
 - `update-net` – ingest a document into the network graph and render it.
+- `publish-field` – publish a Markdown file to Google Docs or update an
+  existing document.
 - `snip-file` – trim a text file down to a manageable token count.
 - `promptdev-bootstrap` – run a three-step shaping routine based on a seed
   prompt.

--- a/breathing_willow/field_publish.py
+++ b/breathing_willow/field_publish.py
@@ -61,3 +61,37 @@ def publish(filepath):
     print(link)
     return link
 
+
+def _doc_id_from_url(url: str) -> str:
+    import re
+
+    m = re.search(r"/d/([a-zA-Z0-9_-]+)", url)
+    if not m:
+        raise ValueError("unable to parse document id from url")
+    return m.group(1)
+
+
+def update(url: str, filepath: str) -> str:
+    """Update an existing Google Doc with contents of ``filepath``."""
+    if not filepath.endswith('.md'):
+        raise ValueError("Only .md files are supported")
+
+    with open(filepath, 'r') as f:
+        md_content = f.read()
+
+    html_content = markdown.markdown(md_content)
+
+    media = MediaIoBaseUpload(
+        io.BytesIO(html_content.encode('utf-8')),
+        mimetype='text/html',
+        resumable=True,
+    )
+
+    file_id = _doc_id_from_url(url)
+    service = _get_drive_service()
+    service.files().update(fileId=file_id, media_body=media).execute()
+
+    link = f"https://docs.google.com/document/d/{file_id}/edit"
+    print(link)
+    return link
+

--- a/breathing_willow_cli/subcommands.py
+++ b/breathing_willow_cli/subcommands.py
@@ -198,6 +198,20 @@ def cmd_promptdev_bootstrap(args: argparse.Namespace) -> None:
             print(f"wrote '{fp_out}'")
 
 
+def cmd_publish_field(args: argparse.Namespace) -> None:
+    from breathing_willow import field_publish
+
+    path = args.file
+    if args.publish:
+        field_publish.publish(path)
+    elif args.update:
+        if not args.url:
+            raise SystemExit("--url is required for update")
+        field_publish.update(args.url, path)
+    else:
+        raise SystemExit("specify --publish or --update")
+
+
 def add_subcommands(subparsers: argparse._SubParsersAction) -> None:
     """Register all breathing-willow subcommands."""
 
@@ -360,4 +374,15 @@ def add_subcommands(subparsers: argparse._SubParsersAction) -> None:
         help="any desired shaping context for step2. often /field/excess.md",
     )
     shape.set_defaults(func=cmd_promptdev_bootstrap)
+
+    publish = subparsers.add_parser(
+        "publish-field", help="publish or update a markdown file to Google Docs"
+    )
+    publish.add_argument("-f", "--file", required=True, help="markdown file")
+    publish.add_argument("--publish", action="store_true", help="publish file")
+    publish.add_argument("-u", "--url", help="existing doc url")
+    publish.add_argument(
+        "--update", action="store_true", help="update the document at --url"
+    )
+    publish.set_defaults(func=cmd_publish_field)
 

--- a/docs/cli/willow-cli.md
+++ b/docs/cli/willow-cli.md
@@ -12,7 +12,7 @@ The output looks like this:
 
 ```
 usage: breathing-willow [-h] [--version]
-                        {ccraft,sense,module-prompt133,log-prompt,history,vc-step,docs,update-net,snip-file,promptdev-bootstrap} ...
+                        {ccraft,sense,module-prompt133,log-prompt,history,vc-step,docs,update-net,publish-field,snip-file,promptdev-bootstrap} ...
 ```
 
 Below is a quick summary of what each subcommand does.
@@ -44,6 +44,10 @@ Build and serve the MkDocs documentation with live reload.
 ### `update-net`
 Ingest a document into the Willow graph and render a visualization.
 Snapshots of the source can be stored alongside the file.
+
+### `publish-field`
+Publish a Markdown file from `/field` to Google Docs or update an existing
+document via its share URL.
 
 ### `snip-file`
 Truncate a text file to the last set of useful tokens. Handy for keeping prompts

--- a/tests/test_publish_field_cli.py
+++ b/tests/test_publish_field_cli.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breathing_willow_cli.breathing_willow import main as cli_main
+import types
+
+fake_md = types.SimpleNamespace(markdown=lambda x: x)
+
+
+def test_publish_field_publish(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'markdown', fake_md)
+    monkeypatch.setitem(sys.modules, 'googleapiclient.discovery', types.SimpleNamespace(build=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'googleapiclient.http', types.SimpleNamespace(MediaIoBaseUpload=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'oauth2client.file', types.SimpleNamespace(Storage=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'oauth2client.client', types.SimpleNamespace(flow_from_clientsecrets=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'oauth2client.tools', types.SimpleNamespace(run_flow=lambda *a, **k: None))
+    from breathing_willow import field_publish
+    calls = {}
+    def fake_publish(fp):
+        calls['fp'] = fp
+    monkeypatch.setattr(field_publish, 'publish', fake_publish)
+    cli_main(['publish-field', '-f', 'x.md', '--publish'])
+    assert calls['fp'] == 'x.md'
+
+
+def test_publish_field_update(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'markdown', fake_md)
+    monkeypatch.setitem(sys.modules, 'googleapiclient.discovery', types.SimpleNamespace(build=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'googleapiclient.http', types.SimpleNamespace(MediaIoBaseUpload=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'oauth2client.file', types.SimpleNamespace(Storage=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'oauth2client.client', types.SimpleNamespace(flow_from_clientsecrets=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, 'oauth2client.tools', types.SimpleNamespace(run_flow=lambda *a, **k: None))
+    from breathing_willow import field_publish
+    calls = {}
+    def fake_update(url, fp):
+        calls['url'] = url
+        calls['fp'] = fp
+    monkeypatch.setattr(field_publish, 'update', fake_update)
+    cli_main(['publish-field', '-f', 'a.md', '--update', '-u', 'http://doc'])
+    assert calls['fp'] == 'a.md'
+    assert calls['url'] == 'http://doc'


### PR DESCRIPTION
## Summary
- integrate `publish-field` subcommand into CLI
- support publishing new docs and updating existing docs
- document usage of `publish-field`
- test the new CLI option

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688279f688908323ac126858e82d6fd5