### PR TITLE
Fix snip-file CLI preserves input

### DIFF
--- a/breathing_willow_cli/subcommands.py
+++ b/breathing_willow_cli/subcommands.py
@@ -101,7 +101,10 @@ def cmd_snip_file(args: argparse.Namespace) -> None:
 
     print("snipping file to last practical context...")
     text = sf.snip_file_to_last_tokens(
-        str(fp), context_scope="practical", aggressive=True
+        str(fp),
+        context_scope="practical",
+        aggressive=False,
+        n_tokens=args.n_tokens,
     )
     fpo = Path(args.output_file)
     fpo.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_snip_file_cli.py
+++ b/tests/test_snip_file_cli.py
@@ -10,6 +10,7 @@ from breathing_willow_cli.breathing_willow import main as cli_main
 def test_snip_file_cli(monkeypatch, tmp_path, capsys):
     test_file = tmp_path / "t.md"
     test_file.write_text("a b c d e")
+    out_file = tmp_path / "o.md"
 
     class FakeEnc:
         def encode(self, text):
@@ -22,19 +23,21 @@ def test_snip_file_cli(monkeypatch, tmp_path, capsys):
 
     from breathing_willow import snip_file as sf
 
-    def fake_snip(fp, context_scope="practical", aggressive=False):
+    calls = {}
+
+    def fake_snip(fp, context_scope="practical", aggressive=False, n_tokens="0"):
+        calls["aggressive"] = aggressive
         p = Path(fp)
         tokens = FakeEnc().encode(p.read_text())
-        new_text = FakeEnc().decode(tokens[-2:])
-        if aggressive:
-            p.write_text(new_text)
-        return new_text
+        return FakeEnc().decode(tokens[-2:])
 
     monkeypatch.setattr(sf, "snip_file_to_last_tokens", fake_snip)
 
-    cli_main(["snip-file", "-f", str(test_file)])
+    cli_main(["snip-file", "-f", str(test_file), "-o", str(out_file)])
 
     out = capsys.readouterr().out
     assert "has 5 tokens" in out
     assert "now has 2 tokens" in out
-    assert test_file.read_text() == "d e"
+    assert calls["aggressive"] is False
+    assert test_file.read_text() == "a b c d e"
+    assert out_file.read_text() == "d e"


### PR DESCRIPTION
## Summary
- avoid rewriting the input file when using `willow snip-file`
- update test to check that input remains unchanged and output contains snipped tokens

## Testing
- `pytest tests/test_snip_file_cli.py::test_snip_file_cli -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828e4090c483239d7cb068d37e731c