### PR TITLE
Add clipboard agent instantiation subcommand

### DIFF
--- a/breathing_willow/__init__.py
+++ b/breathing_willow/__init__.py
@@ -1,5 +1,7 @@
 """Breathing Willow core package."""
 
+from .clipboard_agent import ClipboardAgent
+
 __version__ = "0.1.0"
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "ClipboardAgent"]

--- a/breathing_willow/clipboard_agent.py
+++ b/breathing_willow/clipboard_agent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""ClipboardAgent implementation.
+
+This simple agent persists its context to a markdown file and performs
+minimal decision and action steps. Intended as an example or placeholder
+for more complex agents.
+"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+from .agent import Agent
+
+
+class ClipboardAgent(Agent):
+    """An ``Agent`` that stores and echoes clipboard context."""
+
+    def __init__(self, context_path: Path) -> None:
+        self.context_path = Path(context_path)
+        name = self.context_path.stem
+        super().__init__(name=name, role="clipboard")
+
+    # ------------------------------------------------------------------
+    # Context helpers
+    def load_context(self) -> str:
+        """Return the current context file contents."""
+        if not self.context_path.exists():
+            return ""
+        return self.context_path.read_text(encoding="utf-8")
+
+    def save_context(self, content: str) -> None:
+        """Write ``content`` to the context file."""
+        self.context_path.write_text(content, encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Agent lifecycle
+    def decide(self, goal: str, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Minimal decision step that echoes stored context."""
+        return {"goal": goal, "context": self.load_context()}
+
+    def act(self, decision: Dict[str, Any]) -> Any:
+        """Return the decision as the action result."""
+        return decision

--- a/breathing_willow_cli/subcommands.py
+++ b/breathing_willow_cli/subcommands.py
@@ -4,9 +4,13 @@ import argparse
 import subprocess
 from warnings import warn
 from pathlib import Path
+import json
+from uuid import uuid4
+from datetime import datetime, timezone
 
 from w_cli import diff
 from breathing_willow.willow_viz import WillowGrowth
+from breathing_willow.clipboard_agent import ClipboardAgent
 from .utils import (
     append_shaping_log,
     get_version,
@@ -388,4 +392,61 @@ def add_subcommands(subparsers: argparse._SubParsersAction) -> None:
         "--update", action="store_true", help="update the document at --url"
     )
     publish.set_defaults(func=cmd_publish_field)
+
+    agentic = subparsers.add_parser(
+        "agentic", help="instantiate and manage Willow agents"
+    )
+    agentic.add_argument(
+        "--instantiate-clipboard-agent",
+        action="store_true",
+        help="create a clipboard agent",
+    )
+    agentic.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="path to agent context file",
+    )
+    agentic.set_defaults(func=cmd_agentic)
+
+
+def cmd_agentic(args: argparse.Namespace) -> None:
+    """Instantiate a :class:`ClipboardAgent` and register it."""
+    if not args.instantiate_clipboard_agent:
+        raise SystemExit("--instantiate-clipboard-agent flag is required")
+
+    context_path = Path(args.output).expanduser()
+    if not context_path.exists():
+        context_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "id": str(uuid4()),
+            "name": context_path.stem,
+            "role": "clipboard",
+            "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+        frontmatter = (
+            "---\n"
+            + "\n".join(f"{k}: {v}" for k, v in metadata.items())
+            + "\n---\n\n# Context\n"
+        )
+        context_path.write_text(frontmatter, encoding="utf-8")
+
+    agent = ClipboardAgent(context_path)
+
+    registry_dir = Path.home() / ".willow"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    registry_file = registry_dir / "agents.json"
+    data: dict[str, str] = {}
+    if registry_file.exists():
+        try:
+            data = json.loads(registry_file.read_text())
+        except json.JSONDecodeError:
+            data = {}
+    data[agent.name] = str(context_path)
+    registry_file.write_text(json.dumps(data, indent=2))
+
+    print(
+        f"Created Clipboard Agent '{agent.name}' at {context_path}\n"
+        "Edit this file to modify the agent's behavior."
+    )
 


### PR DESCRIPTION
## Summary
- implement `ClipboardAgent` subclass storing context in markdown file
- add `agentic` CLI subcommand to instantiate clipboard agents and register them
- expose `ClipboardAgent` in package exports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896816c31f48323a53dc76976d6b333