### PR TITLE
feat(cli): add clipboard agent loader

### DIFF
--- a/docs/cli/agentic.md
+++ b/docs/cli/agentic.md
@@ -1,0 +1,57 @@
+# Using `willow agentic --load-clipboard-agent`
+
+This command retrieves a registered clipboard agent by matching a partial UUID in its name, then writes the agent’s full Markdown context to a specified output file. You can then copy and paste the file’s content directly into any LLM session, or use it for offline reference.
+
+## 1. Command Syntax
+
+```bash
+willow agentic --load-clipboard-agent <agent id> -o <output path>
+```
+
+**Arguments:**
+
+* `<agent id>` — A partial UUID string from the agent’s name (e.g., `85165e39`).
+* `-o <output path>` — The path where the agent’s Markdown context will be saved.
+
+## 2. Example
+
+Assume your `~/.willow/agents.json` contains:
+
+```json
+{
+  "clipboard agent test cresting-cloud 85165e39": "/field/clipboard agent test cresting-cloud 85165e39.md"
+}
+```
+
+Running:
+
+```bash
+willow agentic --load-clipboard-agent 85165e39 -o /tmp/myagent-context.md
+```
+
+Will:
+
+1. Search all registered agent names for a substring match with `85165e39`.
+2. Confirm there is **exactly one** match; otherwise, raise an error.
+3. Copy the source file (`/field/clipboard agent test cresting-cloud 85165e39.md`) to `/tmp/myagent-context.md`.
+
+## 3. Output
+
+After success, you’ll see:
+
+```
+Loaded Clipboard Agent 'clipboard agent test cresting-cloud 85165e39'
+Context written to /tmp/myagent-context.md
+```
+
+You can now open `/tmp/myagent-context.md` and paste its contents into any LLM prompt. Whatever is in the Markdown file becomes the injected context.
+
+## 4. Error Handling
+
+* **No Matches** — If no agent name contains the `<agent id>` substring, an error is displayed and no file is written.
+* **Multiple Matches** — If more than one agent matches the substring, an error is displayed prompting you to use a longer identifier.
+
+## 5. Tips
+
+* Use a longer `<agent id>` substring if you have many agents with similar names.
+* You can use the `cat ~/.willow/agents.json` command to inspect all available agents and their stored paths.

--- a/docs/cli/willow-cli.md
+++ b/docs/cli/willow-cli.md
@@ -12,7 +12,7 @@ The output looks like this:
 
 ```
 usage: breathing-willow [-h] [--version]
-                        {ccraft,sense,module-prompt133,log-prompt,history,vc-step,docs,update-net,publish-field,snip-file,promptdev-bootstrap} ...
+                        {ccraft,sense,module-prompt133,log-prompt,history,vc-step,docs,update-net,publish-field,agentic,snip-file,promptdev-bootstrap} ...
 ```
 
 Below is a quick summary of what each subcommand does.
@@ -48,6 +48,10 @@ Snapshots of the source can be stored alongside the file.
 ### `publish-field`
 Publish a Markdown file from `/field` to Google Docs or update an existing
 document via its share URL.
+
+### `agentic`
+Instantiate and manage Willow agents. Create a new clipboard agent or load an
+existing one by partial identifier.
 
 ### `snip-file`
 Truncate a text file to the last set of useful tokens. Handy for keeping prompts

--- a/tests/test_agentic_cli.py
+++ b/tests/test_agentic_cli.py
@@ -1,0 +1,56 @@
+import json
+import sys
+from pathlib import Path
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breathing_willow_cli.breathing_willow import main as cli_main
+
+
+def _setup_registry(tmp_path, monkeypatch, data):
+    home = tmp_path / "home"
+    registry_dir = home / ".willow"
+    registry_dir.mkdir(parents=True)
+    registry_file = registry_dir / "agents.json"
+    registry_file.write_text(json.dumps(data))
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return registry_file
+
+
+def test_load_clipboard_agent_success(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "source.md"
+    src.write_text("hello")
+    agent_name = "clipboard agent test cresting-cloud 85165e39"
+    _setup_registry(tmp_path, monkeypatch, {agent_name: str(src)})
+
+    out_file = tmp_path / "out.md"
+    cli_main(["agentic", "--load-clipboard-agent", "85165e39", "-o", str(out_file)])
+
+    assert out_file.read_text() == "hello"
+    out = capsys.readouterr().out
+    assert f"Loaded Clipboard Agent '{agent_name}'" in out
+    assert f"Context written to {out_file}" in out
+
+
+def test_load_clipboard_agent_no_match(monkeypatch, tmp_path):
+    _setup_registry(tmp_path, monkeypatch, {"some agent 123": str(tmp_path / "a.md")})
+    out_file = tmp_path / "o.md"
+    with pytest.raises(SystemExit) as e:
+        cli_main(["agentic", "--load-clipboard-agent", "zzz", "-o", str(out_file)])
+    assert "no agent id matching" in str(e.value)
+
+
+def test_load_clipboard_agent_multiple_matches(monkeypatch, tmp_path):
+    src1 = tmp_path / "a.md"; src1.write_text("a")
+    src2 = tmp_path / "b.md"; src2.write_text("b")
+    _setup_registry(tmp_path, monkeypatch, {"agent 123": str(src1), "other 123": str(src2)})
+    out_file = tmp_path / "o.md"
+    with pytest.raises(SystemExit) as e:
+        cli_main(["agentic", "--load-clipboard-agent", "123", "-o", str(out_file)])
+    assert "multiple agents match" in str(e.value)


### PR DESCRIPTION
## Summary
- add `--load-clipboard-agent` option to `willow agentic`
- document clipboard agent loading
- test loading behavior and error cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ba6b37d48323b72c646241889c59