### PR TITLE
Add recent morphs copy mode to Morphtoc CLI

### DIFF
--- a/vismmorphtoc.py
+++ b/vismmorphtoc.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from visms.morphtoc import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- support copying N most recently edited morph files via `--recent`/`--n`
- expose new copy mode in parser and CLI
- add thin wrapper `vismmorphtoc.py` for direct invocation

## Testing
- `pytest`
- `python vismmorphtoc.py --recent --n 2 --params path=/tmp/vault,pattern=morph*.md`


------
https://chatgpt.com/codex/tasks/task_e_68b1eade8eb883239ad3ab2b26452914