### PR TITLE
Refactor wrap vism to canonical form

### DIFF
--- a/visms/vism_wrap.py
+++ b/visms/vism_wrap.py
@@ -1,170 +1,342 @@
-"""
-Wrap vism stub - 要 point , this is what should be updated 
-"""
+#!/usr/bin/env python3
+"""wrap vism — payload -> envelope."""
 
 from __future__ import annotations
+
 import argparse
 import base64
 import binascii
 import dataclasses
+from contextlib import contextmanager
 import datetime as _dt
 import hashlib
 import json
+import os
+import shutil
+import stat
 import sys
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, TypedDict, Union, cast
+from typing import Any, Callable, Dict, Generic, Optional, Tuple, TypeVar
 
-__all__ = [
-    "Envelope",
-    "Outcome",
-    "Ports",
-    "wrap_core",
-    "run_cli",
-    "__version__",
-]
+VISM_CODE = "wrap"
+__version__ = "0.2.1"
+DOCS_TARGET = str(Path("~/.local/share/vism/docs").expanduser() / f"{VISM_CODE}.{__version__}.md")
 
-__version__ = "0.2.0"
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Outcome(Generic[T]):
+    ok: bool
+    value: Optional[T] = None
+    error: Optional[str] = None
+    receipts: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Payload:
+    bytes_: bytes
+    media_type: str
+    source: str
+
 
 @dataclass(frozen=True)
 class Envelope:
     id: str
-    content_hash_sha256: str
+    content_hash: str
     created_at: str
     media_type: str
     source: str
 
-@dataclass(frozen=True)
-class Outcome:
-    ok: bool
-    value: Optional[Envelope]
-    error: Optional[str]
-    receipts: Dict[str, Any]
 
-class Ports(TypedDict):
+@dataclass(frozen=True)
+class Ctx:
     clock: Callable[[], _dt.datetime]
-    crypto: Callable[[bytes], str]
+    sha256: Callable[[bytes], str]
+    uuid7: Callable[[], str]
+    span: Callable[[str, Any], Any]
+
 
 def _utc_now() -> _dt.datetime:
     return _dt.datetime.now(tz=_dt.timezone.utc)
 
-def _sha256_hex(b: bytes) -> str:
-    return hashlib.sha256(b).hexdigest()
 
-DEFAULT_PORTS: Ports = {
-    "clock": _utc_now,
-    "crypto": _sha256_hex,
-}
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
 
-_WRAP_NAMESPACE = uuid.UUID("5a9a8e3d-1b55-43c6-9b0b-0a6a6e1a0d67")
 
-def _b64_to_bytes(s: str) -> bytes:
-    try:
-        return base64.b64decode(s, validate=True)
-    except (binascii.Error, ValueError) as e:
-        raise ValueError("invalid_base64") from e
+def _uuid7() -> str:
+    return uuid.uuid7().hex if hasattr(uuid, "uuid7") else uuid.uuid4().hex
 
-def _ensure_media_type(mt: Optional[str]) -> str:
-    mt = (mt or "").strip()
-    return mt or "application/octet-stream"
 
-def _ensure_source(src: Optional[str]) -> str:
-    src = (src or "").strip()
-    return src or "cli"
+@contextmanager
+def _null_span(name: str, **fields: Any):  # pragma: no cover - telemetry stub
+    yield
 
-def _make_id_from_hash(hash_hex: str) -> str:
-    return str(uuid.uuid5(_WRAP_NAMESPACE, hash_hex))
 
-def _isoformat_utc(dt: _dt.datetime) -> str:
-    return dt.isoformat()
+DEFAULT_CTX = Ctx(
+    clock=_utc_now,
+    sha256=_sha256,
+    uuid7=_uuid7,
+    span=lambda name, **fields: _null_span(name, **fields),
+)
 
-def wrap_core(input_obj: Dict[str, Any], ports: Optional[Ports] = None) -> Outcome:
-    p = ports or DEFAULT_PORTS
-    try:
-        if not isinstance(input_obj, dict):
-            raise KeyError
-        if input_obj.get("vism") != "wrap":
-            pass
-        payload = input_obj["input"]
-        if not isinstance(payload, dict):
-            raise KeyError
-        b64 = payload["bytes_"]
-        media_type = _ensure_media_type(payload.get("media_type"))
-        source = _ensure_source(payload.get("source"))
-        if not isinstance(b64, str):
-            raise KeyError
-    except KeyError:
-        return Outcome(ok=False, value=None, error="input_malformed",
-                       receipts={"wrap": "error", "ports": {"clock": "utc", "crypto": "sha256"}})
-    try:
-        raw_bytes = _b64_to_bytes(b64)
-    except ValueError as e:
-        return Outcome(ok=False, value=None, error=str(e),
-                       receipts={"wrap": "error", "ports": {"clock": "utc", "crypto": "sha256"}})
-    if len(raw_bytes) == 0:
-        return Outcome(ok=False, value=None, error="empty_payload",
-                       receipts={"wrap": "error", "ports": {"clock": "utc", "crypto": "sha256"}})
-    hash_hex = p["crypto"](raw_bytes)
-    env_id = _make_id_from_hash(hash_hex)
-    created_at = _isoformat_utc(p["clock"]())
-    envelope = Envelope(id=env_id, content_hash_sha256=hash_hex,
-                        created_at=created_at, media_type=media_type, source=source)
-    receipts = {"wrap": "ok", "ports": {"clock": "utc", "crypto": "sha256"}}
-    return Outcome(ok=True, value=envelope, error=None, receipts=receipts)
 
-_DOCS_MD = """# Wrap Vism — Morph Brief 冊 documentation
-Documentation intentionally stripped down for module integrity.
+# ----- core -------------------------------------------------------------------
+
+def wrap_apply(payload: Payload, ctx: Ctx = DEFAULT_CTX) -> Outcome[Envelope]:
+    """Wrap ``payload`` into an :class:`Envelope`."""
+
+    with ctx.span("wrap.apply", source=payload.source, media_type=payload.media_type):
+        if not payload.bytes_:
+            return Outcome(False, None, "empty_payload", receipts={})
+
+        content_hash = ctx.sha256(payload.bytes_)
+        eid = ctx.uuid7()
+        created_at = ctx.clock().isoformat()
+        env = Envelope(
+            id=eid,
+            content_hash=content_hash,
+            created_at=created_at,
+            media_type=payload.media_type,
+            source=payload.source,
+        )
+        receipts = {"content_hash": content_hash, "created_at": created_at}
+        return Outcome(True, env, None, receipts=receipts)
+
+
+# ----- helpers ----------------------------------------------------------------
+
+def _req_from_stream_or_file(arg: Optional[str]) -> Dict[str, Any]:
+    if arg == "-":
+        return json.load(sys.stdin)
+    if arg:
+        with open(arg, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    if not sys.stdin.isatty():
+        data = sys.stdin.read()
+        if data.strip():
+            return json.loads(data)
+    return {}
+
+
+def _parse_overrides(items: Optional[list[str]]) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    for part in items or []:
+        if "=" not in part:
+            raise ValueError(f"bad override '{part}', expected k=v")
+        k, v = part.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def _merge_overrides(base: Dict[str, Any], overrides: Dict[str, str]) -> Dict[str, Any]:
+    d = dict(base or {})
+    inp = dict(d.get("input") or {})
+    for k, v in overrides.items():
+        inp[k] = v
+    d["input"] = inp
+    d.setdefault("vism", VISM_CODE)
+    return d
+
+
+def _interactive_request() -> Dict[str, Any]:
+    def ask(prompt: str, default: str = "") -> str:
+        resp = input(f"{prompt} [{default}]: ").strip()
+        return resp or default
+
+    print("No JSON input detected. Enter values interactively.", file=sys.stderr)
+    b64 = ask("Enter base64 bytes_")
+    media_type = ask("Enter media_type", "application/octet-stream")
+    source = ask("Enter source", "cli")
+    return {"vism": VISM_CODE, "input": {"bytes_": b64, "media_type": media_type, "source": source}}
+
+
+def _out_to_json(out: Outcome[Envelope]) -> Dict[str, Any]:
+    val = dataclasses.asdict(out.value) if out.value else None
+    return {"ok": out.ok, "value": val, "error": out.error, "receipts": out.receipts}
+
+
+# ----- installer and docs -----------------------------------------------------
+
+def _install_paths(code: str = VISM_CODE) -> Tuple[str, str]:
+    home = Path.home()
+    share_dir = home / ".local" / "share" / "vism"
+    bin_dir = home / ".local" / "bin"
+    share_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    return str(share_dir / f"{code}.py"), str(bin_dir / code)
+
+
+_LAUNCHER = """#!/usr/bin/env bash
+set -euo pipefail
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+exec "$PYTHON_BIN" "{module_path}" "$@"
 """
 
-def _print_json(obj: Any, pretty: bool) -> None:
-    if pretty:
-        json.dump(obj, sys.stdout, indent=2, sort_keys=False)
-    else:
-        json.dump(obj, sys.stdout, separators=(",", ":"), ensure_ascii=False)
-    sys.stdout.write("\n")
-    sys.stdout.flush()
 
-def _read_stdin_json() -> Union[Dict[str, Any], list, None]:
-    data = sys.stdin.read()
-    if not data.strip():
-        return None
-    try:
-        return cast(Union[Dict[str, Any], list], json.loads(data))
-    except json.JSONDecodeError:
-        return None
+def install_self() -> Dict[str, str]:
+    module_target, launcher_target = _install_paths(VISM_CODE)
+    this_path = os.path.abspath(sys.argv[0])
+    shutil.copyfile(this_path, module_target)
+    with open(launcher_target, "w", encoding="utf-8") as f:
+        f.write(_LAUNCHER.format(module_path=module_target))
+    st = os.stat(launcher_target)
+    os.chmod(launcher_target, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return {"module": module_target, "launcher": launcher_target}
 
-def run_cli(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(prog="vism_wrap", description="Wrap Vism — Payload → Envelope")
-    parser.add_argument("--pretty", action="store_true")
-    parser.add_argument("--document", action="store_true")
-    parser.add_argument("-o","--output", type=str, default="")
-    parser.add_argument("--version", action="store_true")
-    args = parser.parse_args(argv)
+
+def emit_document(path: str = DOCS_TARGET) -> str:
+    p = Path(path).expanduser()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"# docs for {VISM_CODE}",
+        f"version: {__version__}",
+        "input: Payload{bytes_, media_type, source}",
+        "output: Outcome<Envelope{content_hash,id,created_at,media_type,source}>",
+        "invariants:",
+        "- hash_is_deterministic",
+        "- rejects_empty",
+        "failures:",
+        "- empty_payload",
+        "- bad_base64",
+        "- invalid_input",
+    ]
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(p)
+
+
+# ----- properties -------------------------------------------------------------
+
+def _hash_is_deterministic() -> None:
+    payload = Payload(b"abc", "text/plain", "unit-test")
+    out1 = wrap_apply(payload, DEFAULT_CTX)
+    out2 = wrap_apply(payload, DEFAULT_CTX)
+    assert out1.ok and out2.ok
+    assert out1.value.content_hash == out2.value.content_hash
+    print("hash_is_deterministic: ok", file=sys.stderr)
+
+
+def _rejects_empty() -> None:
+    payload = Payload(b"", "text/plain", "unit-test")
+    out = wrap_apply(payload, DEFAULT_CTX)
+    assert not out.ok and out.error == "empty_payload"
+    print("rejects_empty: ok", file=sys.stderr)
+
+
+def run_self_tests() -> int:
+    _hash_is_deterministic()
+    _rejects_empty()
+    return 0
+
+
+# ----- CLI --------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog=VISM_CODE, description="Wrap vism — Payload → Envelope")
+    p.add_argument("--input", help="JSON request path or '-' for stdin")
+    p.add_argument("--override", action="append", help="Override input field (k=v)")
+    p.add_argument("--pretty", action="store_true", help="Pretty-print output JSON")
+    p.add_argument("--install", action="store_true", help="Install launcher to ~/.local/bin")
+    p.add_argument("--document", action="store_true", help=f"Write docs to {DOCS_TARGET}")
+    p.add_argument("--version", action="store_true", help="Print version and exit")
+    p.add_argument("--self-test", action="store_true", help="Run self-tests and exit")
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = build_parser()
+    args = ap.parse_args(argv)
+
     if args.version:
         print(__version__)
         return 0
-    if args.document:
-        if args.output:
-            outdir = Path(args.output)
-            outdir.mkdir(parents=True, exist_ok=True)
-            (outdir / "wrap_vism.md").write_text(_DOCS_MD, encoding="utf-8")
-            print(str(outdir / "wrap_vism.md"))
-        else:
-            print(_DOCS_MD)
-        return 0
-    parsed = _read_stdin_json()
-    if parsed is None or not isinstance(parsed, dict):
-        _print_json({"ok": False,"value": None,"error": "input_malformed",
-                    "receipts": {"wrap": "error","ports": {"clock": "utc", "crypto": "sha256"}}}, pretty=args.pretty)
-        return 1
-    outcome = wrap_core(parsed, ports=DEFAULT_PORTS)
-    if outcome.value is not None:
-        value = dataclasses.asdict(outcome.value)
-    else:
-        value = None
-    _print_json({"ok": outcome.ok,"value": value,"error": outcome.error,"receipts": outcome.receipts}, pretty=args.pretty)
-    return 0
 
-if __name__ == "__main__":
-    raise SystemExit(run_cli())
+    if args.self_test:
+        return run_self_tests()
+
+    if args.document:
+        path = emit_document()
+        print(path)
+        return 0
+
+    if args.install:
+        info = install_self()
+        print("installed:", file=sys.stderr)
+        print(f"  module  : {info['module']}", file=sys.stderr)
+        print(f"  launcher: {info['launcher']}", file=sys.stderr)
+        print(f"next: {VISM_CODE} --help", file=sys.stderr)
+        return 0
+
+    try:
+        req = _req_from_stream_or_file(args.input)
+    except Exception:
+        req = {}
+
+    if not req:
+        req = _interactive_request()
+
+    if args.override:
+        try:
+            overrides = _parse_overrides(args.override)
+            req = _merge_overrides(req, overrides)
+        except ValueError:
+            out = Outcome[Envelope](ok=False, error="invalid_input", receipts={})
+            json.dump(_out_to_json(out), sys.stdout, ensure_ascii=False)
+            sys.stdout.write("\n")
+            return 1
+
+    try:
+        if req.get("vism") not in (None, VISM_CODE):
+            raise ValueError("wrong vism")
+        inp = req.get("input")
+        if not isinstance(inp, dict):
+            raise ValueError("missing input")
+        b64 = inp.get("bytes_")
+        if not isinstance(b64, str):
+            raise ValueError("missing bytes_")
+        media_type = (inp.get("media_type") or "application/octet-stream").strip() or "application/octet-stream"
+        source = (inp.get("source") or "cli").strip() or "cli"
+    except Exception:
+        out = Outcome[Envelope](ok=False, error="invalid_input", receipts={})
+        json.dump(_out_to_json(out), sys.stdout, indent=2 if args.pretty else None, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 1
+
+    try:
+        raw = base64.b64decode(b64, validate=True)
+    except (binascii.Error, ValueError):
+        out = Outcome[Envelope](ok=False, error="bad_base64", receipts={})
+        json.dump(_out_to_json(out), sys.stdout, indent=2 if args.pretty else None, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 1
+
+    payload = Payload(bytes_=raw, media_type=media_type, source=source)
+    out = wrap_apply(payload, DEFAULT_CTX)
+    json.dump(_out_to_json(out), sys.stdout, indent=2 if args.pretty else None, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0 if out.ok else 1
+
+
+run_cli = main
+
+
+__all__ = [
+    "Payload",
+    "Envelope",
+    "Outcome",
+    "Ctx",
+    "wrap_apply",
+    "install_self",
+    "emit_document",
+    "run_self_tests",
+    "run_cli",
+    "__version__",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- adopt canonical floating-squid structure for wrap vism
- add install/document helpers, CLI overrides, and interactive fallback
- embed self-tests for deterministic hash and empty payload rejection

## Testing
- `python visms/vism_wrap.py --self-test`
- `python visms/vism_wrap.py --document`
- `echo '{"vism":"wrap","input":{"bytes_":"aGVsbG8=","media_type":"text/plain","source":"unit"}}' | python visms/vism_wrap.py --input -`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b46ff8bc4c83238f03c30ce1350b96