### PR TITLE
feat(android): add share archiver and envelope db

### DIFF
--- a/android-app/src/main/kotlin/app/MainActivity.kt
+++ b/android-app/src/main/kotlin/app/MainActivity.kt
@@ -1,0 +1,79 @@
+package app
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.lifecycleScope
+import app.archive.ShareArchiver
+import app.db.EnvelopeEntity
+import app.db.EnvelopeRepository
+import kotlinx.coroutines.launch
+
+class MainActivity : ComponentActivity() {
+    private val snackbar = SnackbarHostState()
+    private val repo by lazy { EnvelopeRepository.get(this) }
+    private val archiver by lazy { ShareArchiver(this) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handleShareIntent(intent)
+        setContent {
+            val items = repo.observeAll().collectAsState(initial = emptyList())
+            Scaffold(snackbarHost = { SnackbarHost(snackbar) }) { padding ->
+                EnvelopeList(items.value)
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.let { handleShareIntent(it) }
+    }
+
+    private fun handleShareIntent(intent: Intent) {
+        if (intent.action == Intent.ACTION_SEND) {
+            val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) ?: return
+            val type = intent.type ?: "application/octet-stream"
+            lifecycleScope.launch {
+                val env = archiver.archive(uri, uri.lastPathSegment, type, target = "local")
+                val entity = EnvelopeEntity(
+                    sha256 = env.contentHashSha256,
+                    filename = env.filename,
+                    size = env.sizeBytes,
+                    mediaType = env.mediaType,
+                    createdAt = env.createdAtUtc,
+                    filePath = env.filePath?.toString(),
+                    archivedPath = env.archivedPath?.toString() ?: "",
+                    sidecarPath = env.sidecarPath?.toString() ?: ""
+                )
+                repo.insert(entity)
+                snackbar.showSnackbar("Saved")
+            }
+        }
+    }
+}
+
+@Composable
+fun EnvelopeList(envelopes: List<EnvelopeEntity>) {
+    if (envelopes.isEmpty()) {
+        Text("No entries")
+    } else {
+        LazyColumn(modifier = androidx.compose.ui.Modifier.fillMaxSize()) {
+            items(envelopes) { env ->
+                Card { Text(env.filename ?: env.sha256) }
+            }
+        }
+    }
+}

--- a/android-app/src/main/kotlin/app/archive/ShareArchiver.kt
+++ b/android-app/src/main/kotlin/app/archive/ShareArchiver.kt
@@ -1,0 +1,36 @@
+package app.archive
+
+import android.content.Context
+import android.net.Uri
+import core.archive.Envelope
+import core.archive.planArchive
+import edge.archive.fs.ArchiveFsAdapter
+import edge.archive.fs.ArchiverCommitBus
+import java.nio.file.Path
+import java.time.Instant
+
+class ShareArchiver(private val context: Context) {
+    private val bus = ArchiverCommitBus()
+    private val adapter = ArchiveFsAdapter(bus)
+
+    /**
+     * Archive bytes from a given [Uri]. Returns the resulting [Envelope].
+     */
+    fun archive(uri: Uri, filename: String?, mediaType: String, target: String): Envelope {
+        val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() } ?: ByteArray(0)
+        val sha = java.security.MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+        val env = Envelope(
+            contentHashSha256 = sha,
+            createdAtUtc = Instant.now(),
+            mediaType = mediaType,
+            filename = filename,
+            sizeBytes = bytes.size.toLong(),
+            origin = "share-intent",
+            target = target,
+            filePath = uri.path?.let { Path.of(it) }
+        )
+        val plan = planArchive(env, bytes)
+        adapter.commit(bytes, plan)
+        return env.copy(archivedPath = plan.dataPath, sidecarPath = plan.sidecarPath)
+    }
+}

--- a/android-app/src/main/kotlin/app/db/EnvelopeDao.kt
+++ b/android-app/src/main/kotlin/app/db/EnvelopeDao.kt
@@ -1,0 +1,16 @@
+package app.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EnvelopeDao {
+    @Query("SELECT * FROM envelopes ORDER BY createdAt DESC")
+    fun observeAll(): Flow<List<EnvelopeEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(entity: EnvelopeEntity)
+}

--- a/android-app/src/main/kotlin/app/db/EnvelopeDatabase.kt
+++ b/android-app/src/main/kotlin/app/db/EnvelopeDatabase.kt
@@ -1,0 +1,23 @@
+package app.db
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [EnvelopeEntity::class], version = 1)
+abstract class EnvelopeDatabase : RoomDatabase() {
+    abstract fun envelopeDao(): EnvelopeDao
+
+    companion object {
+        @Volatile private var instance: EnvelopeDatabase? = null
+
+        fun get(context: Context): EnvelopeDatabase = instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                EnvelopeDatabase::class.java,
+                "envelopes.db"
+            ).build().also { instance = it }
+        }
+    }
+}

--- a/android-app/src/main/kotlin/app/db/EnvelopeEntity.kt
+++ b/android-app/src/main/kotlin/app/db/EnvelopeEntity.kt
@@ -1,0 +1,22 @@
+package app.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.Index
+import java.time.Instant
+
+@Entity(
+    tableName = "envelopes",
+    indices = [Index(value = ["sha256"], unique = true)]
+)
+data class EnvelopeEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val sha256: String,
+    val filename: String?,
+    val size: Long,
+    val mediaType: String,
+    val createdAt: Instant,
+    val filePath: String?,
+    val archivedPath: String,
+    val sidecarPath: String
+)

--- a/android-app/src/main/kotlin/app/db/EnvelopeRepository.kt
+++ b/android-app/src/main/kotlin/app/db/EnvelopeRepository.kt
@@ -1,0 +1,20 @@
+package app.db
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class EnvelopeRepository private constructor(private val dao: EnvelopeDao) {
+    fun observeAll() = dao.observeAll()
+
+    suspend fun insert(entity: EnvelopeEntity) = withContext(Dispatchers.IO) {
+        dao.insert(entity)
+    }
+
+    companion object {
+        fun get(context: Context): EnvelopeRepository {
+            val db = EnvelopeDatabase.get(context)
+            return EnvelopeRepository(db.envelopeDao())
+        }
+    }
+}

--- a/android-app/src/main/kotlin/core/archive/ArchiveCore.kt
+++ b/android-app/src/main/kotlin/core/archive/ArchiveCore.kt
@@ -16,7 +16,10 @@ data class Envelope(
     val filename: String?,
     val sizeBytes: Long,
     val origin: String,
-    val target: String
+    val target: String,
+    val filePath: Path? = null,
+    val archivedPath: Path? = null,
+    val sidecarPath: Path? = null
 )
 
 /** Plan produced by the pure archive core before any side effects. */
@@ -61,13 +64,46 @@ private fun inferExtension(mediaType: String, filename: String?): String {
 
 private fun buildSidecarJson(envelope: Envelope): String {
     // Construct JSON with stable key order manually
-    return "{" +
-        "\"content_hash_sha256\":\"${envelope.contentHashSha256}\"," +
-        "\"created_at\":\"${envelope.createdAtUtc.toString()}\"," +
-        "\"media_type\":\"${envelope.mediaType}\"," +
-        (envelope.filename?.let { "\"filename\":\"$it\"," } ?: "") +
-        "\"size_bytes\":${envelope.sizeBytes}," +
-        "\"origin\":\"${envelope.origin}\"," +
-        "\"target\":\"${envelope.target}\"" +
-        "}"
+    return buildString {
+        append('{')
+        append("\"content_hash_sha256\":\"")
+        append(envelope.contentHashSha256)
+        append("\",")
+        append("\"created_at\":\"")
+        append(envelope.createdAtUtc.toString())
+        append("\",")
+        append("\"media_type\":\"")
+        append(envelope.mediaType)
+        append("\",")
+        envelope.filename?.let {
+            append("\"filename\":\"")
+            append(it)
+            append("\",")
+        }
+        append("\"size_bytes\":")
+        append(envelope.sizeBytes)
+        append(',')
+        append("\"origin\":\"")
+        append(envelope.origin)
+        append("\",")
+        append("\"target\":\"")
+        append(envelope.target)
+        append('\"')
+        envelope.filePath?.let {
+            append(",\"file_path\":\"")
+            append(it.toString())
+            append('\"')
+        }
+        envelope.archivedPath?.let {
+            append(",\"archived_path\":\"")
+            append(it.toString())
+            append('\"')
+        }
+        envelope.sidecarPath?.let {
+            append(",\"sidecar_path\":\"")
+            append(it.toString())
+            append('\"')
+        }
+        append('}')
+    }
 }


### PR DESCRIPTION
## Summary
- extend Envelope model with file paths and update sidecar generation
- add Room entities/dao/repository for storing archived Envelopes
- wire ShareIntent handling and Compose UI listing with snackbar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6705959fc8323ba2432ce0d7f3bb2