### PR TITLE
Implement ShareReceiver with hashing and Room persistence

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -58,6 +58,8 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -22,6 +22,27 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".share.ShareReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="video/*" />
+                <data android:mimeType="application/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="video/*" />
+                <data android:mimeType="application/*" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/android-app/app/src/main/java/app/zero/inlet/core/Sha256Hasher.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/core/Sha256Hasher.kt
@@ -1,0 +1,10 @@
+package app.zero.inlet.core
+
+import java.security.MessageDigest
+
+object Sha256Hasher {
+    fun hash(bytes: ByteArray): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+        return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+}

--- a/android-app/app/src/main/java/app/zero/inlet/core/UtcClock.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/core/UtcClock.kt
@@ -1,0 +1,10 @@
+package app.zero.inlet.core
+
+import java.time.Instant
+
+object UtcClock {
+    fun nowZ(): String {
+        val iso = Instant.now().toString()
+        return if (iso.endsWith("Z")) iso else "${iso}Z"
+    }
+}

--- a/android-app/app/src/main/java/app/zero/inlet/db/EnvelopeDao.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/EnvelopeDao.kt
@@ -1,0 +1,18 @@
+package app.zero.inlet.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface EnvelopeDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insert(entity: EnvelopeEntity): Long
+
+    @Query("SELECT * FROM envelope WHERE sha256 = :sha")
+    fun findBySha(sha: String): EnvelopeEntity?
+
+    @Query("SELECT COUNT(*) FROM envelope")
+    fun count(): Int
+}

--- a/android-app/app/src/main/java/app/zero/inlet/db/EnvelopeEntity.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/EnvelopeEntity.kt
@@ -1,0 +1,20 @@
+package app.zero.inlet.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "envelope",
+    indices = [Index(value = ["sha256"], unique = true)]
+)
+data class EnvelopeEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val sha256: String,
+    val filename: String,
+    val mime: String,
+    @ColumnInfo(name = "size_bytes") val sizeBytes: Long,
+    @ColumnInfo(name = "created_at_Z") val createdAtZ: String,
+    @ColumnInfo(name = "source_package") val sourcePackage: String
+)

--- a/android-app/app/src/main/java/app/zero/inlet/db/InletDatabase.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/InletDatabase.kt
@@ -1,0 +1,24 @@
+package app.zero.inlet.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+@Database(
+    entities = [EnvelopeEntity::class, ReceiptEntity::class, SpanEntity::class],
+    version = 1
+)
+abstract class InletDatabase : RoomDatabase() {
+    abstract fun envelopeDao(): EnvelopeDao
+    abstract fun receiptDao(): ReceiptDao
+    abstract fun spanDao(): SpanDao
+
+    companion object {
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // No-op for initial version
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/app/zero/inlet/db/ReceiptDao.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/ReceiptDao.kt
@@ -1,0 +1,10 @@
+package app.zero.inlet.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+
+@Dao
+interface ReceiptDao {
+    @Insert
+    fun insert(entity: ReceiptEntity): Long
+}

--- a/android-app/app/src/main/java/app/zero/inlet/db/ReceiptEntity.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/ReceiptEntity.kt
@@ -1,0 +1,26 @@
+package app.zero.inlet.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "receipt",
+    foreignKeys = [
+        ForeignKey(
+            entity = EnvelopeEntity::class,
+            parentColumns = ["sha256"],
+            childColumns = ["envelope_sha256"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("envelope_sha256")]
+)
+data class ReceiptEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val type: String,
+    @ColumnInfo(name = "envelope_sha256") val envelopeSha256: String,
+    @ColumnInfo(name = "created_at_Z") val createdAtZ: String
+)

--- a/android-app/app/src/main/java/app/zero/inlet/db/SpanDao.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/SpanDao.kt
@@ -1,0 +1,10 @@
+package app.zero.inlet.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+
+@Dao
+interface SpanDao {
+    @Insert
+    fun insert(entity: SpanEntity): Long
+}

--- a/android-app/app/src/main/java/app/zero/inlet/db/SpanEntity.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/db/SpanEntity.kt
@@ -1,0 +1,15 @@
+package app.zero.inlet.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "span")
+data class SpanEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "trace_id") val traceId: String,
+    val action: String,
+    @ColumnInfo(name = "started_at_Z") val startedAtZ: String,
+    @ColumnInfo(name = "ended_at_Z") val endedAtZ: String,
+    val status: String
+)

--- a/android-app/app/src/main/java/app/zero/inlet/share/ShareReceiver.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/share/ShareReceiver.kt
@@ -1,0 +1,79 @@
+package app.zero.inlet.share
+
+import android.content.BroadcastReceiver
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.room.Room
+import app.zero.inlet.core.Sha256Hasher
+import app.zero.inlet.core.UtcClock
+import app.zero.inlet.db.EnvelopeEntity
+import app.zero.inlet.db.InletDatabase
+import app.zero.inlet.db.ReceiptEntity
+import java.io.File
+
+class ShareReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val uris = when (intent.action) {
+            Intent.ACTION_SEND -> {
+                val uri: Uri? = intent.getParcelableExtra(Intent.EXTRA_STREAM)
+                uri?.let { listOf(it) } ?: emptyList()
+            }
+            Intent.ACTION_SEND_MULTIPLE -> {
+                intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM) ?: emptyList()
+            }
+            else -> emptyList()
+        }
+
+        if (uris.isEmpty()) return
+
+        val resolver = context.contentResolver
+        val mime = intent.type ?: ""
+        val sourcePackage = intent.getStringExtra("source_package") ?: intent.`package` ?: ""
+        val now = UtcClock.nowZ()
+
+        val db = Room.databaseBuilder(context, InletDatabase::class.java, "inlet.db")
+            .allowMainThreadQueries()
+            .build()
+
+        uris.forEach { uri ->
+            val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return@forEach
+            val sha = Sha256Hasher.hash(bytes)
+            val name = queryName(resolver, uri) ?: uri.lastPathSegment ?: "unknown"
+            val dest = File(File(context.filesDir, "ingest"), "$sha/$name")
+            if (!dest.exists()) {
+                dest.parentFile?.mkdirs()
+                dest.writeBytes(bytes)
+            }
+            val envelope = EnvelopeEntity(
+                sha256 = sha,
+                filename = name,
+                mime = mime,
+                sizeBytes = bytes.size.toLong(),
+                createdAtZ = now,
+                sourcePackage = sourcePackage
+            )
+            db.envelopeDao().insert(envelope)
+            db.receiptDao().insert(
+                ReceiptEntity(
+                    type = "share",
+                    envelopeSha256 = sha,
+                    createdAtZ = now
+                )
+            )
+        }
+        db.close()
+    }
+
+    private fun queryName(resolver: ContentResolver, uri: Uri): String? {
+        resolver.query(uri, null, null, null, null)?.use { cursor ->
+            val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (index != -1 && cursor.moveToFirst()) {
+                return cursor.getString(index)
+            }
+        }
+        return null
+    }
+}

--- a/android-app/app/src/test/java/app/zero/inlet/share/ShareReceiverTest.kt
+++ b/android-app/app/src/test/java/app/zero/inlet/share/ShareReceiverTest.kt
@@ -1,0 +1,53 @@
+package app.zero.inlet.share
+
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.robolectric.Shadows
+import app.zero.inlet.core.Sha256Hasher
+import app.zero.inlet.db.InletDatabase
+import androidx.room.Room
+import app.zero.inlet.db.EnvelopeDao
+import java.io.ByteArrayInputStream
+import java.io.File
+
+class ShareReceiverTest {
+    @Test
+    fun duplicateSharesSingleEnvelope() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val bytes = "hello world".toByteArray()
+        val uri = Uri.parse("content://test/hello.txt")
+        Shadows.shadowOf(context.contentResolver).registerInputStream(uri, ByteArrayInputStream(bytes))
+
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra("source_package", "com.example.sender")
+        }
+
+        val receiver = ShareReceiver()
+        receiver.onReceive(context, intent)
+
+        // Re-register stream for second share
+        Shadows.shadowOf(context.contentResolver).registerInputStream(uri, ByteArrayInputStream(bytes))
+        receiver.onReceive(context, intent)
+
+        val sha = Sha256Hasher.hash(bytes)
+        val db: InletDatabase = Room.databaseBuilder(context, InletDatabase::class.java, "inlet.db")
+            .allowMainThreadQueries()
+            .build()
+        val envelopeDao: EnvelopeDao = db.envelopeDao()
+
+        assertEquals(1, envelopeDao.count())
+        val envelope = envelopeDao.findBySha(sha)!!
+        assertEquals("hello.txt", envelope.filename)
+        assertEquals("text/plain", envelope.mime)
+        assertTrue(envelope.createdAtZ.endsWith("Z"))
+        val expectedFile = File(File(context.filesDir, "ingest"), "$sha/hello.txt")
+        assertTrue(expectedFile.exists())
+        db.close()
+    }
+}

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 ksp = "2.0.21-1.0.28"
 room = "2.6.1"
+robolectric = "4.12.1"
+androidxTestCore = "1.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +30,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-test-core = { group = "androidx.test", name = "core-ktx", version.ref = "androidxTestCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add ShareReceiver to handle ACTION_SEND and ACTION_SEND_MULTIPLE intents
- compute SHA-256 hashes, persist files and metadata via Room
- include Robolectric test for duplicate share idempotency

## Testing
- `ANDROID_SDK_ROOT=/tmp/android-sdk ./gradlew :app:testDebugUnitTest` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. Failed to install the following Android SDK packages as some licences have not been accepted.)*

------
https://chatgpt.com/codex/tasks/task_e_68b683d829148323ab7c64fe8179d932