### PR TITLE
Implement JVM ArchivePlanner with deterministic sidecar

### DIFF
--- a/android-app/app/src/main/java/app/zero/inlet/archive/ArchivePlanner.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/archive/ArchivePlanner.kt
@@ -1,0 +1,90 @@
+package app.zero.inlet.archive
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.TreeMap
+
+/** Metadata needed to plan an archive. */
+data class EnvelopeMeta(
+    val sha256: String,
+    val mediaType: String? = null,
+    val filename: String? = null,
+)
+
+/** Deterministic archive plan with pre-built sidecar bytes. */
+data class ArchivePlan(
+    val dataPath: Path,
+    val sidecarPath: Path,
+    val target: String,
+    val ext: String,
+    val shardPath: Path,
+    val sha256: String,
+    val nowZ: Instant,
+    val sidecarBytes: ByteArray,
+)
+
+/** Pure planner computing archive locations and sidecar JSON. */
+object ArchivePlanner {
+    private val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd").withZone(ZoneOffset.UTC)
+
+    fun plan(meta: EnvelopeMeta, target: String, now: Instant = Instant.now()): ArchivePlan {
+        val ext = inferExt(meta.mediaType, meta.filename)
+        val dateShard = formatter.format(now)
+        val shardPath = Paths.get("archive", *dateShard.split('/').toTypedArray())
+        val dataPath = shardPath.resolve("${meta.sha256}.$ext")
+        val sidecarPath = shardPath.resolve("${meta.sha256}.json")
+        val sidecarJson = canonicalJson(meta, target, ext, now)
+        val bytes = sidecarJson.toByteArray(StandardCharsets.UTF_8)
+        return ArchivePlan(dataPath, sidecarPath, target, ext, shardPath, meta.sha256, now, bytes)
+    }
+
+    private fun inferExt(mediaType: String?, filename: String?): String {
+        val mimeExt = when (mediaType?.lowercase(Locale.ROOT)) {
+            "image/jpeg" -> "jpg"
+            "image/png" -> "png"
+            "application/pdf" -> "pdf"
+            else -> null
+        }
+        val nameExt = filename?.substringAfterLast('.', "")
+            ?.lowercase(Locale.ROOT)
+            ?.takeIf { it.isNotEmpty() }
+        return mimeExt ?: nameExt ?: "bin"
+    }
+
+    private fun canonicalJson(meta: EnvelopeMeta, target: String, ext: String, now: Instant): String {
+        val map = TreeMap<String, String>()
+        map["created_at"] = now.toString()
+        map["ext"] = ext
+        meta.filename?.let { map["filename"] = it }
+        meta.mediaType?.let { map["media_type"] = it }
+        map["sha256"] = meta.sha256
+        map["target"] = target
+        val sb = StringBuilder()
+        sb.append('{')
+        val iter = map.entries.iterator()
+        while (iter.hasNext()) {
+            val (k, v) = iter.next()
+            sb.append('"').append(k).append('"').append(':').append('"').append(escape(v)).append('"')
+            if (iter.hasNext()) sb.append(',')
+        }
+        sb.append('}')
+        return sb.toString()
+    }
+
+    private fun escape(s: String): String {
+        val out = StringBuilder()
+        for (c in s) {
+            when (c) {
+                '\\' -> out.append("\\\\")
+                '"' -> out.append("\\\"")
+                else -> out.append(c)
+            }
+        }
+        return out.toString()
+    }
+}

--- a/android-app/app/src/test/java/app/zero/inlet/archive/ArchivePlannerTest.kt
+++ b/android-app/app/src/test/java/app/zero/inlet/archive/ArchivePlannerTest.kt
@@ -1,0 +1,77 @@
+package app.zero.inlet.archive
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+import java.time.Instant
+
+class ArchivePlannerTest {
+    private val now = Instant.parse("2024-03-04T05:06:07Z")
+    private val meta = EnvelopeMeta(
+        sha256 = "a".repeat(64),
+        mediaType = "image/jpeg",
+        filename = "photo.jpg"
+    )
+    private val target = "disk"
+
+    @Test
+    fun deterministicPaths() {
+        val plan1 = ArchivePlanner.plan(meta, target, now)
+        val plan2 = ArchivePlanner.plan(meta, target, now)
+        assertEquals(plan1.dataPath, plan2.dataPath)
+        assertEquals(plan1.sidecarPath, plan2.sidecarPath)
+        assertEquals(plan1.shardPath, plan2.shardPath)
+        assertEquals(plan1.ext, plan2.ext)
+    }
+
+    @Test
+    fun sidecarByteStability() {
+        val plan1 = ArchivePlanner.plan(meta, target, now)
+        val plan2 = ArchivePlanner.plan(meta, target, now)
+        assertTrue(plan1.sidecarBytes.contentEquals(plan2.sidecarBytes))
+    }
+
+    @Test
+    fun sidecarCanonical() {
+        val plan = ArchivePlanner.plan(meta, target, now)
+        val expected = "{\"created_at\":\"2024-03-04T05:06:07Z\",\"ext\":\"jpg\",\"filename\":\"photo.jpg\",\"media_type\":\"image/jpeg\",\"sha256\":\"${"a".repeat(64)}\",\"target\":\"disk\"}"
+        assertEquals(expected, String(plan.sidecarBytes, StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun shardingFormat() {
+        val plan = ArchivePlanner.plan(meta, target, now)
+        assertEquals(Paths.get("archive", "2024", "03", "04"), plan.shardPath)
+        assertEquals(plan.shardPath.resolve("${meta.sha256}.${plan.ext}"), plan.dataPath)
+        assertEquals(plan.shardPath.resolve("${meta.sha256}.json"), plan.sidecarPath)
+    }
+
+    @Test
+    fun extFromMimeJpg() {
+        val m = EnvelopeMeta(sha256 = "b".repeat(64), mediaType = "image/jpeg", filename = null)
+        val plan = ArchivePlanner.plan(m, target, now)
+        assertEquals("jpg", plan.ext)
+    }
+
+    @Test
+    fun extFromMimePng() {
+        val m = EnvelopeMeta(sha256 = "c".repeat(64), mediaType = "image/png", filename = null)
+        val plan = ArchivePlanner.plan(m, target, now)
+        assertEquals("png", plan.ext)
+    }
+
+    @Test
+    fun extFromFilenamePdf() {
+        val m = EnvelopeMeta(sha256 = "d".repeat(64), mediaType = null, filename = "report.PDF")
+        val plan = ArchivePlanner.plan(m, target, now)
+        assertEquals("pdf", plan.ext)
+    }
+
+    @Test
+    fun extFallbackBin() {
+        val m = EnvelopeMeta(sha256 = "e".repeat(64), mediaType = null, filename = null)
+        val plan = ArchivePlanner.plan(m, target, now)
+        assertEquals("bin", plan.ext)
+    }
+}


### PR DESCRIPTION
## Summary
- add pure JVM ArchivePlanner that plans archive and canonical sidecar
- infer file extensions from MIME or filename
- test deterministic paths, sidecar stability, and sharding

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b683d983908323adc9506c1332c47f