### PR TITLE
Ensure Agent timestamps are UTC

### DIFF
--- a/breathing_willow/agent.py
+++ b/breathing_willow/agent.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 import uuid
-import datetime
+from datetime import datetime, timezone
 
 class Agent(ABC):
     """
@@ -17,14 +17,15 @@ class Agent(ABC):
         self.role = role                   # Functional or mythic role
         self.tools = tools or {}           # Tool interfaces assigned to this agent
         self.memory: List[Dict[str, Any]] = []
-        self.created_at = datetime.datetime.utcnow()
+        self.created_at = datetime.now(timezone.utc)
         self.last_active = None
 
     def observe(self, observation: Dict[str, Any]) -> None:
         """Store observation with timestamp."""
-        observation["timestamp"] = datetime.datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc)
+        observation["timestamp"] = now.isoformat().replace("+00:00", "Z")
         self.memory.append(observation)
-        self.last_active = datetime.datetime.utcnow()
+        self.last_active = now
 
     @abstractmethod
     def decide(self, goal: str, context: Dict[str, Any]) -> Dict[str, Any]:
@@ -58,7 +59,7 @@ class Agent(ABC):
             "role": self.role,
             "tools": list(self.tools.keys()),
             "memory": self.memory,
-            "created_at": self.created_at.isoformat(),
-            "last_active": self.last_active.isoformat() if self.last_active else None
+            "created_at": self.created_at.isoformat().replace("+00:00", "Z"),
+            "last_active": self.last_active.isoformat().replace("+00:00", "Z") if self.last_active else None,
         }
 

--- a/tests/test_agent_timestamps.py
+++ b/tests/test_agent_timestamps.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breathing_willow.agent import Agent
+
+
+class DummyAgent(Agent):
+    def decide(self, goal: str, context: dict) -> dict:
+        return {}
+
+    def act(self, decision: dict):
+        return None
+
+
+def test_all_timestamps_end_with_z():
+    agent = DummyAgent(name="dummy", role="tester")
+    state = agent.export_state()
+    assert state["created_at"].endswith("Z")
+    agent.observe({"event": "test"})
+    state = agent.export_state()
+    assert state["last_active"].endswith("Z")
+    for obs in state["memory"]:
+        assert obs["timestamp"].endswith("Z")


### PR DESCRIPTION
## Summary
- Record Agent timestamps in UTC and serialize with `Z`
- Test that exported state timestamps follow `Z`-suffixed format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6853a2548832382b23c6383f14852