### PR TITLE
feat: commit archive and enqueue unique upload work

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -57,7 +57,10 @@ dependencies {
     // --- Core ---
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.work.runtime.ktx)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.work.testing)
+    testImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 

--- a/android-app/app/src/main/java/app/zero/inlet/archive/ArchiveCommitter.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/archive/ArchiveCommitter.kt
@@ -1,0 +1,77 @@
+package app.zero.inlet.archive
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import app.zero.inlet.upload.UploadWorker
+import java.io.File
+import java.io.FileOutputStream
+
+/** Simple tracing span placeholder. */
+data class Span(val name: String)
+
+/** Simple receipt event. */
+data class Receipt(val type: String)
+
+/** Plan describing where to store data and sidecar. */
+data class ArchivePlan(
+    val dataPath: String,
+    val sidecarPath: String,
+    val sha256: String,
+    val target: String,
+    val sidecarBytes: ByteArray
+)
+
+/**
+ * Adapter committing archive data to disk and enqueuing upload work.
+ * Files are first written to temporary `.part` files under a `tmp` directory,
+ * fsynced and then atomically renamed into their final shard path.
+ */
+class ArchiveCommitter(
+    private val context: Context,
+    private val rootDir: File,
+    private val events: MutableCollection<Any> = mutableListOf()
+) {
+    fun commit(plan: ArchivePlan, bytes: ByteArray, failAfterWrite: Boolean = false) {
+        val dataFile = File(rootDir, plan.dataPath)
+        val sidecarFile = File(rootDir, plan.sidecarPath)
+        dataFile.parentFile?.mkdirs()
+        sidecarFile.parentFile?.mkdirs()
+
+        val tmpDir = File(rootDir, "tmp").apply { mkdirs() }
+        val tmpData = File(tmpDir, dataFile.name + ".part")
+        val tmpSide = File(tmpDir, sidecarFile.name + ".part")
+
+        FileOutputStream(tmpData).use { fos ->
+            fos.write(bytes)
+            fos.fd.sync()
+        }
+        FileOutputStream(tmpSide).use { fos ->
+            fos.write(plan.sidecarBytes)
+            fos.fd.sync()
+        }
+
+        if (failAfterWrite) {
+            // Simulate failure before rename for testing
+            throw RuntimeException("simulated_failure")
+        }
+
+        if (!tmpData.renameTo(dataFile) || !tmpSide.renameTo(sidecarFile)) {
+            tmpData.delete()
+            tmpSide.delete()
+            throw IllegalStateException("rename_failed")
+        }
+
+        val name = "${plan.target}:${plan.sha256}"
+        val request = OneTimeWorkRequestBuilder<UploadWorker>().build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(name, ExistingWorkPolicy.KEEP, request)
+
+        events.add(Span("archiver.commit"))
+        events.add(Receipt("archiver.commit"))
+    }
+
+    fun getEvents(): List<Any> = events.toList()
+}
+

--- a/android-app/app/src/main/java/app/zero/inlet/upload/UploadWorker.kt
+++ b/android-app/app/src/main/java/app/zero/inlet/upload/UploadWorker.kt
@@ -1,0 +1,15 @@
+package app.zero.inlet.upload
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+/**
+ * Simplified worker representing an upload task.
+ * The worker does no real work and simply succeeds.
+ */
+class UploadWorker(appContext: Context, params: WorkerParameters) :
+    CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result = Result.success()
+}
+

--- a/android-app/app/src/test/java/app/zero/inlet/archive/ArchiveCommitterTest.kt
+++ b/android-app/app/src/test/java/app/zero/inlet/archive/ArchiveCommitterTest.kt
@@ -1,0 +1,82 @@
+package app.zero.inlet.archive
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import java.io.File
+import java.nio.file.Files
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
+
+class ArchiveCommitterTest {
+
+    private fun initWorkManager(context: Context): WorkManager {
+        val config = Configuration.Builder()
+            .setMinimumLoggingLevel(Log.DEBUG)
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+        return WorkManager.getInstance(context)
+    }
+
+    private fun samplePlan(): ArchivePlan = ArchivePlan(
+        dataPath = "archive/data.bin",
+        sidecarPath = "archive/data.json",
+        sha256 = "sha",
+        target = "t",
+        sidecarBytes = "{}".toByteArray()
+    )
+
+    @Test
+    fun commitWritesAndCleansPartFiles() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        initWorkManager(context)
+        val root = Files.createTempDirectory("test").toFile()
+        val committer = ArchiveCommitter(context, root)
+        val plan = samplePlan()
+        committer.commit(plan, "hello".toByteArray())
+
+        val dataFile = File(root, plan.dataPath)
+        val sidecarFile = File(root, plan.sidecarPath)
+        assertTrue(dataFile.exists())
+        assertTrue(sidecarFile.exists())
+
+        val tmp = File(root, "tmp")
+        assertFalse(File(tmp, dataFile.name + ".part").exists())
+        assertFalse(File(tmp, sidecarFile.name + ".part").exists())
+    }
+
+    @Test
+    fun failureLeavesNoFinalFiles() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        initWorkManager(context)
+        val root = Files.createTempDirectory("test").toFile()
+        val committer = ArchiveCommitter(context, root)
+        val plan = samplePlan()
+        assertThrows(RuntimeException::class.java) {
+            committer.commit(plan, "hello".toByteArray(), failAfterWrite = true)
+        }
+        assertFalse(File(root, plan.dataPath).exists())
+        assertFalse(File(root, plan.sidecarPath).exists())
+    }
+
+    @Test
+    fun enqueueIsUnique() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val wm = initWorkManager(context)
+        val root = Files.createTempDirectory("test").toFile()
+        val committer = ArchiveCommitter(context, root)
+        val plan = samplePlan()
+        committer.commit(plan, "hi".toByteArray())
+        committer.commit(plan, "hi".toByteArray())
+
+        val workInfos = wm.getWorkInfosForUniqueWork("${plan.target}:${plan.sha256}").get()
+        assertEquals(1, workInfos.size)
+    }
+}
+

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 ksp = "2.0.21-1.0.28"
 room = "2.6.1"
+work = "2.9.0"
+testCore = "1.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +30,9 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "work" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "testCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- atomically commit archive files via temporary `.part` shards
- enqueue `UploadWorker` uniquely per target and sha256
- add tests covering `.part` cleanup, failure behavior and unique work

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b683db14b083239699406e0afd68f7