### PR TITLE
Add safer file handling to snip-file utility

### DIFF
--- a/breathing_willow/snip_file.py
+++ b/breathing_willow/snip_file.py
@@ -1,58 +1,87 @@
 from pathlib import Path
+import shutil
 import tiktoken
 
 
-def snip_file_to_last_tokens(fp, context_scope='practical', aggressive=False,
-                             n_tokens='0') -> str:
-    """Snips a file to retain only the last N tokens of text content.
+def snip_file_to_last_tokens(
+    fp,
+    context_scope: str = "practical",
+    aggressive: bool = False,
+    n_tokens: str = "0",
+    output_path: str | Path | None = None,
+) -> str:
+    """Snip ``fp`` to retain only the last ``n_tokens`` tokens of text.
 
-    Reads a file, tokenizes its contents using the GPT tokenizer, and returns
-    (or optionally overwrites) only the final N tokens. The value of N is chosen
-    based on the `context_scope` setting, which controls whether to preserve a
-    maximum or practical context window for downstream processing.
-
-    ## Parameters
+    Parameters
+    ----------
     fp : str or Path
         Path to the input file to be snipped.
-    context_scope : {'max', 'practical'}, optional
-        Token retention policy. If 'max', retains 128,000 tokens. If 'practical',
-        retains 3,000. Defaults to 'practical'.
+    context_scope : {"max", "practical"}, optional
+        Token retention policy. If ``"max"``, retains 128,000 tokens. If
+        ``"practical"``, retains 3,000. Defaults to ``"practical"``.
     aggressive : bool, optional
-        If True, overwrites the original file with the snipped output. If False,
-        returns the truncated text as a string. Defaults to False.
+        If True, write the snipped output to ``output_path`` if provided,
+        otherwise overwrite ``fp`` after creating a ``.bak`` backup. If False,
+        only return the snipped text. Defaults to False.
     n_tokens : int, optional
-        if passed, then last n tokens will be taken. arg context_scope will be
-        simply overwritten 
+        If passed, then last ``n`` tokens will be taken. ``context_scope`` will
+        be ignored. Defaults to "0".
+    output_path : str or Path, optional
+        Destination for snipped content when ``aggressive`` is True. If omitted
+        the original file is overwritten after backing it up.
 
-    ## Returns
+    Returns
+    -------
     str
-        The truncated text content, unless `aggressive` is True.
+        The truncated text content.
 
-    ## Raises
+    Raises
+    ------
     ValueError
-        If `context_scope` is not one of {'max', 'practical'}.
+        If ``context_scope`` is not one of {"max", "practical"}.
+    FileNotFoundError
+        If ``fp`` does not exist.
+    OSError
+        If an I/O error occurs while reading or writing files.
     """
     n_tokens = int(n_tokens)
     if not n_tokens > 0:
-        if context_scope == 'max':
+        if context_scope == "max":
             n_tokens = 128_000  # GPT-4o max context length
-        elif context_scope == 'practical':
+        elif context_scope == "practical":
             n_tokens = 3_000
         else:
             raise ValueError("context_scope must be 'max' or 'practical'")
     else:
         n_tokens = int(n_tokens)
 
+    src_path = Path(fp)
+    try:
+        text = src_path.read_text(encoding="utf-8")
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"file not found: {src_path}") from e
+    except OSError as e:
+        raise OSError(f"error reading {src_path}: {e}") from e
+
     enc = tiktoken.encoding_for_model("gpt-4")
-    text = Path(fp).read_text(encoding='utf-8')
     tokens = enc.encode(text)
     snipped_tokens = tokens[-n_tokens:]
-
     o = enc.decode(snipped_tokens)
-    if not aggressive:
-        return o
-    else:
-        with open(fp, 'w') as f:
-            f.write(o)
+
+    if aggressive:
+        target = Path(output_path) if output_path else src_path
+        if target.resolve() == src_path.resolve():
+            backup_path = src_path.with_suffix(src_path.suffix + ".bak")
+            try:
+                shutil.copy2(src_path, backup_path)
+            except OSError as e:
+                raise OSError(f"error creating backup {backup_path}: {e}") from e
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(o, encoding="utf-8")
+        except OSError as e:
+            raise OSError(f"error writing {target}: {e}") from e
+
+    return o
 
 endpoint = snip_file_to_last_tokens

--- a/tests/test_snip_file_backup.py
+++ b/tests/test_snip_file_backup.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_backup_and_missing_file(monkeypatch, tmp_path):
+    class FakeEnc:
+        def encode(self, text):
+            return text.split()
+        def decode(self, tokens):
+            return " ".join(tokens)
+
+    fake_tiktoken = types.SimpleNamespace(encoding_for_model=lambda m: FakeEnc())
+    monkeypatch.setitem(sys.modules, "tiktoken", fake_tiktoken)
+
+    from breathing_willow import snip_file as sf
+
+    src = tmp_path / "f.txt"
+    src.write_text("a b c d e", encoding="utf-8")
+
+    out_text = sf.snip_file_to_last_tokens(src, aggressive=True, n_tokens="2")
+    assert out_text == "d e"
+    assert src.read_text(encoding="utf-8") == "d e"
+    backup = src.with_suffix(src.suffix + ".bak")
+    assert backup.exists()
+    assert backup.read_text(encoding="utf-8") == "a b c d e"
+
+    missing = tmp_path / "missing.txt"
+    try:
+        sf.snip_file_to_last_tokens(missing, aggressive=True)
+    except FileNotFoundError as e:
+        assert "file not found" in str(e)
+    else:
+        assert False, "expected FileNotFoundError"


### PR DESCRIPTION
## Summary
- Support optional output path and automatic backup when snipping files
- Use UTF-8 encoding and better error handling for snip-file CLI
- Test backup behavior and missing file errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6853a31688323b7787f4368534644