### PR TITLE
refactor: optional nltk setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ $ bash zzero-dev-env-setup.sh
 ```
 
 There are no strict dependencies yet, but a Python environment with `pytest` installed will help you run future tests.
+
+If you plan to use features that depend on NLTK tokenizers or stopwords, run the
+setup helper once to download the required corpora:
+
+```bash
+python -c "from breathing_willow import setup_nltk; setup_nltk()"
+```
+
+The corpora are stored locally so subsequent runs work offline.
 ## CLI Quick Start
 
 You can check the project version with:

--- a/breathing_willow/__init__.py
+++ b/breathing_willow/__init__.py
@@ -1,7 +1,8 @@
 """Breathing Willow core package."""
 
 from .clipboard_agent import ClipboardAgent
+from .helpers import setup_nltk
 
 __version__ = "0.1.0"
 
-__all__ = ["__version__", "ClipboardAgent"]
+__all__ = ["__version__", "ClipboardAgent", "setup_nltk"]

--- a/breathing_willow/export_kernel.py
+++ b/breathing_willow/export_kernel.py
@@ -436,13 +436,9 @@ class TurnSummaryAnnotator:
 
         try:  # attempt to load nltk stopwords
             import nltk
-
-            try:
-                stop_words = set(nltk.corpus.stopwords.words("english"))
-            except LookupError:
-                nltk.download("stopwords", quiet=True)
-                stop_words = set(nltk.corpus.stopwords.words("english"))
+            stop_words = set(nltk.corpus.stopwords.words("english"))
         except Exception:
+            # call ``breathing_willow.setup_nltk()`` to download these corpora
             stop_words = {
                 "the",
                 "and",

--- a/breathing_willow/helpers.py
+++ b/breathing_willow/helpers.py
@@ -4,6 +4,28 @@ import re
 _ASSET_DIR = Path(__file__).resolve().parent / "assets"
 
 
+def setup_nltk() -> None:
+    """Ensure required NLTK corpora are available.
+
+    Downloads "punkt" and "stopwords" only if the corpora are missing.
+    Clients should call this function once during setup.
+    """
+    try:  # pragma: no cover - optional dependency
+        import nltk
+    except Exception:  # pragma: no cover - missing nltk
+        return
+
+    resources = [
+        ("tokenizers/punkt", "punkt"),
+        ("corpora/stopwords", "stopwords"),
+    ]
+    for path, package in resources:
+        try:
+            nltk.data.find(path)
+        except LookupError:
+            nltk.download(package, quiet=True)
+
+
 def strip_markdown_formatting(fp: str) -> None:
     """Aggressively strip markdown formatting from a file and overwrite it."""
     path = Path(fp)
@@ -56,4 +78,4 @@ def load_asset(name, ext='txt'):
     return path.read_text()
 
 
-__all__ = ["load_asset"]
+__all__ = ["load_asset", "setup_nltk", "strip_markdown_formatting"]

--- a/breathing_willow/willow_viz.py
+++ b/breathing_willow/willow_viz.py
@@ -50,12 +50,11 @@ except Exception:  # pragma: no cover - optional dependency
 
 try:
     import nltk
-    nltk.download('punkt', quiet=True)
-    nltk.download('stopwords', quiet=True)
     from nltk.tokenize import word_tokenize
     from nltk.corpus import stopwords as nltk_stopwords
     STOP_WORDS = set(nltk_stopwords.words('english'))
 except Exception:  # missing nltk or corpus
+    # call ``breathing_willow.setup_nltk()`` to download these corpora
     word_tokenize = None
     STOP_WORDS = {
         'a', 'an', 'the', 'and', 'or', 'but', 'if', 'while', 'of', 'at', 'by',

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -6,6 +6,9 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from breathing_willow.export_kernel import ChatExportArchiver
+# To use NLTK stopwords during tests, ensure corpora are installed:
+# from breathing_willow import setup_nltk
+# setup_nltk()
 
 
 def make_conversation():

--- a/tests/test_update_net.py
+++ b/tests/test_update_net.py
@@ -5,6 +5,9 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import breathing_willow.willow_viz as willow_viz
+# To run with full tokenization, ensure NLTK corpora are installed:
+# from breathing_willow import setup_nltk
+# setup_nltk()
 
 # Avoid NLTK downloads during tests
 willow_viz.word_tokenize = None


### PR DESCRIPTION
## Summary
- add `setup_nltk` helper to check/download required corpora
- remove implicit `nltk.download` calls from export and viz modules
- document NLTK corpora requirement in README and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6853babf0832390aaa51dce2ef127