### PR TITLE
Add traversal limits and robust root checks to diff utilities

### DIFF
--- a/tests/test_w_diff.py
+++ b/tests/test_w_diff.py
@@ -1,6 +1,6 @@
 import re
 from pathlib import Path
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 import pytest
 
 from w_cli import diff as wdiff
@@ -37,3 +37,34 @@ def test_cli_help(capsys):
     help_text = capsys.readouterr().out
     assert "w diff" in help_text
     assert "--window" in help_text
+
+
+def test_find_modified_texts_root_missing():
+    start = datetime.now(timezone.utc) - timedelta(hours=1)
+    end = datetime.now(timezone.utc)
+    with pytest.raises(FileNotFoundError):
+        wdiff.find_modified_texts("/does/not/exist", start, end)
+
+
+def test_find_modified_texts_max_depth(tmp_path):
+    (tmp_path / "a.txt").write_text("hi")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("hi")
+    start = datetime.now(timezone.utc) - timedelta(hours=1)
+    end = datetime.now(timezone.utc)
+    paths = wdiff.find_modified_texts(str(tmp_path), start, end, max_depth=0)
+    assert (tmp_path / "a.txt") in paths
+    assert (sub / "b.txt") not in paths
+
+
+def test_find_modified_texts_exclude(tmp_path):
+    keep = tmp_path / "keep.txt"
+    keep.write_text("hi")
+    skip = tmp_path / "skip.txt"
+    skip.write_text("hi")
+    start = datetime.now(timezone.utc) - timedelta(hours=1)
+    end = datetime.now(timezone.utc)
+    paths = wdiff.find_modified_texts(str(tmp_path), start, end, exclude=["*/skip.txt"])
+    assert keep in paths
+    assert skip not in paths


### PR DESCRIPTION
## Summary
- verify root paths before scanning and raise `FileNotFoundError`
- add optional exclude patterns and max-depth traversal limits
- skip unreadable paths when inspecting file stats
- extend tests for new traversal options

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6853ccf0883238b46a0f16f47b1ac