### PR TITLE
Raise minSdk to 26 and tidy theme

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "com.mfme.kernel"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/android-app/app/src/main/res/values/themes.xml
+++ b/android-app/app/src/main/res/values/themes.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- App theme that pulls in Material3 and removes the action bar -->
-    <style name="Theme.Kernel" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- You can add color/shape overrides later; keep minimal for now -->
-    </style>
+    <style name="Theme.Kernel" parent="Theme.Material3.DayNight.NoActionBar"/>
 </resources>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.app"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
## Summary
- Raise `minSdk` to 26 and ensure both modules target/compile SDK 34
- Define `Theme.Kernel` inheriting from `Theme.Material3.DayNight.NoActionBar`
- Keep Material3 dependency for consistent styling

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c0d1325fd4832394c5c3da26832578