### PR TITLE
feat: scaffold upload worker and cloud binding

### DIFF
--- a/android-app/app/schemas/com.mfme.kernel.data.KernelDatabase/4.json
+++ b/android-app/app/schemas/com.mfme.kernel.data.KernelDatabase/4.json
@@ -1,0 +1,232 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "00000000000000000000000000000000",
+    "entities": [
+      {
+        "tableName": "envelopes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sha256` TEXT NOT NULL, `mime` TEXT, `text` TEXT, `filename` TEXT, `sourcePkgRef` TEXT NOT NULL, `receivedAtUtc` INTEGER NOT NULL, `metaJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mime",
+            "columnName": "mime",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sourcePkgRef",
+            "columnName": "sourcePkgRef",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivedAtUtc",
+            "columnName": "receivedAtUtc",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaJson",
+            "columnName": "metaJson",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_envelopes_sha256",
+            "unique": true,
+            "columnNames": [
+              "sha256"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_envelopes_sha256` ON `${TABLE_NAME}` (`sha256`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "receipts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ok` INTEGER NOT NULL, `code` TEXT NOT NULL, `adapter` TEXT NOT NULL, `tsUtcIso` TEXT NOT NULL, `envelopeId` INTEGER, `envelopeSha256` TEXT, `message` TEXT, `spanId` TEXT NOT NULL, `receiptSha256` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ok",
+            "columnName": "ok",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adapter",
+            "columnName": "adapter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tsUtcIso",
+            "columnName": "tsUtcIso",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "envelopeId",
+            "columnName": "envelopeId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "envelopeSha256",
+            "columnName": "envelopeSha256",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "spanId",
+            "columnName": "spanId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receiptSha256",
+            "columnName": "receiptSha256",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "spans",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`spanId` TEXT NOT NULL, `adapter` TEXT NOT NULL, `startNanos` INTEGER NOT NULL, `endNanos` INTEGER NOT NULL, `envelopeId` INTEGER, `envelopeSha256` TEXT, PRIMARY KEY(`spanId`))",
+        "fields": [
+          {
+            "fieldPath": "spanId",
+            "columnName": "spanId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adapter",
+            "columnName": "adapter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startNanos",
+            "columnName": "startNanos",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endNanos",
+            "columnName": "endNanos",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "envelopeId",
+            "columnName": "envelopeId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "envelopeSha256",
+            "columnName": "envelopeSha256",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "spanId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cloud_binding",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`envelopeId` INTEGER NOT NULL, `driveFileId` TEXT NOT NULL, `uploadedAtUtc` INTEGER NOT NULL, `md5` TEXT, `bytes` INTEGER, PRIMARY KEY(`envelopeId`))",
+        "fields": [
+          {"fieldPath": "envelopeId", "columnName": "envelopeId", "affinity": "INTEGER", "notNull": true},
+          {"fieldPath": "driveFileId", "columnName": "driveFileId", "affinity": "TEXT", "notNull": true},
+          {"fieldPath": "uploadedAtUtc", "columnName": "uploadedAtUtc", "affinity": "INTEGER", "notNull": true},
+          {"fieldPath": "md5", "columnName": "md5", "affinity": "TEXT", "notNull": false},
+          {"fieldPath": "bytes", "columnName": "bytes", "affinity": "INTEGER", "notNull": false}
+        ],
+        "primaryKey": {"autoGenerate": false, "columnNames": ["envelopeId"]},
+        "indices": [
+          {
+            "name": "index_cloud_binding_driveFileId",
+            "unique": true,
+            "columnNames": ["driveFileId"],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cloud_binding_driveFileId` ON `${TABLE_NAME}` (`driveFileId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '00000000000000000000000000000000')"
+    ]
+  }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/data/KernelDatabase.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/KernelDatabase.kt
@@ -3,14 +3,16 @@ package com.mfme.kernel.data
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.mfme.kernel.data.cloud.CloudBinding
+import com.mfme.kernel.data.cloud.CloudBindingDao
 import com.mfme.kernel.data.telemetry.ReceiptEntity
 import com.mfme.kernel.data.telemetry.SpanEntity
 import com.mfme.kernel.data.telemetry.ReceiptDao
 import com.mfme.kernel.data.telemetry.SpanDao
 
 @Database(
-    entities = [Envelope::class, ReceiptEntity::class, SpanEntity::class],
-    version = 3,
+    entities = [Envelope::class, ReceiptEntity::class, SpanEntity::class, CloudBinding::class],
+    version = 4,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -18,4 +20,5 @@ abstract class KernelDatabase : RoomDatabase() {
     abstract fun envelopeDao(): EnvelopeDao
     abstract fun receiptDao(): ReceiptDao
     abstract fun spanDao(): SpanDao
+    abstract fun cloudBindingDao(): CloudBindingDao
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/data/KernelMigrations.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/KernelMigrations.kt
@@ -40,3 +40,11 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
         )
     }
 }
+
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS cloud_binding (envelopeId INTEGER NOT NULL PRIMARY KEY, driveFileId TEXT NOT NULL, uploadedAtUtc INTEGER NOT NULL, md5 TEXT, bytes INTEGER, UNIQUE(driveFileId))"
+        )
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/data/cloud/CloudBinding.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/cloud/CloudBinding.kt
@@ -1,0 +1,18 @@
+package com.mfme.kernel.data.cloud
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.Instant
+
+@Entity(
+    tableName = "cloud_binding",
+    indices = [Index("driveFileId", unique = true)]
+)
+data class CloudBinding(
+    @PrimaryKey val envelopeId: Long,
+    val driveFileId: String,
+    val uploadedAtUtc: Instant,
+    val md5: String?,
+    val bytes: Long?
+)

--- a/android-app/app/src/main/java/com/mfme/kernel/data/cloud/CloudBindingDao.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/cloud/CloudBindingDao.kt
@@ -1,0 +1,18 @@
+package com.mfme.kernel.data.cloud
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface CloudBindingDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(binding: CloudBinding): Long
+
+    @Query("SELECT * FROM cloud_binding WHERE envelopeId = :envelopeId")
+    suspend fun findByEnvelopeId(envelopeId: Long): CloudBinding?
+
+    @Query("SELECT * FROM cloud_binding WHERE driveFileId = :driveFileId")
+    suspend fun findByDriveFileId(driveFileId: String): CloudBinding?
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/di/AppModule.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/di/AppModule.kt
@@ -7,6 +7,7 @@ import com.mfme.kernel.data.KernelRepository
 import com.mfme.kernel.data.KernelRepositoryImpl
 import com.mfme.kernel.data.MIGRATION_1_2
 import com.mfme.kernel.data.MIGRATION_2_3
+import com.mfme.kernel.data.MIGRATION_3_4
 import com.mfme.kernel.telemetry.ErrorEmitter
 import com.mfme.kernel.telemetry.NdjsonSink
 import com.mfme.kernel.telemetry.ReceiptEmitter
@@ -15,7 +16,7 @@ import kotlinx.coroutines.Dispatchers
 object AppModule {
     fun provideDatabase(context: Context): KernelDatabase =
         Room.databaseBuilder(context, KernelDatabase::class.java, "kernel.db")
-            .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+            .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
             .build()
 
     fun provideReceiptEmitter(context: Context, db: KernelDatabase): ReceiptEmitter {

--- a/android-app/app/src/main/java/com/mfme/kernel/work/UploadScheduler.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/work/UploadScheduler.kt
@@ -1,0 +1,26 @@
+package com.mfme.kernel.work
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+
+/**
+ * Schedules unique upload work keyed by sha256.
+ */
+object UploadScheduler {
+    fun enqueue(context: Context, sha256: String) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.UNMETERED)
+            .build()
+        val work = OneTimeWorkRequestBuilder<UploadWorker>()
+            .setInputData(workDataOf(UploadWorker.KEY_SHA256 to sha256))
+            .setConstraints(constraints)
+            .build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork("upload:$sha256", ExistingWorkPolicy.KEEP, work)
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/work/UploadWorker.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/work/UploadWorker.kt
@@ -1,0 +1,20 @@
+package com.mfme.kernel.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+/**
+ * Stub worker for Morph 2 background Drive uploads.
+ * TODO: implement stream → verify → bind pipeline.
+ */
+class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        // Implementation pending
+        return Result.success()
+    }
+
+    companion object {
+        const val KEY_SHA256 = "sha256"
+    }
+}

--- a/android-app/app/src/test/java/com/mfme/kernel/CloudBindingDaoTest.kt
+++ b/android-app/app/src/test/java/com/mfme/kernel/CloudBindingDaoTest.kt
@@ -1,0 +1,49 @@
+package com.mfme.kernel
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.mfme.kernel.data.KernelDatabase
+import com.mfme.kernel.data.cloud.CloudBinding
+import com.mfme.kernel.data.cloud.CloudBindingDao
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+class CloudBindingDaoTest {
+    private lateinit var db: KernelDatabase
+    private lateinit var dao: CloudBindingDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, KernelDatabase::class.java).build()
+        dao = db.cloudBindingDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insertAndFindBinding() = runBlocking {
+        val binding = CloudBinding(
+            envelopeId = 1L,
+            driveFileId = "drive123",
+            uploadedAtUtc = Instant.EPOCH,
+            md5 = "md5",
+            bytes = 123L
+        )
+        dao.insert(binding)
+        val fetched = dao.findByEnvelopeId(1L)
+        Assert.assertNotNull(fetched)
+        Assert.assertEquals("drive123", fetched?.driveFileId)
+    }
+}

--- a/android-app/core/src/main/java/app/zero/core/cloud/DriveAdapter.kt
+++ b/android-app/core/src/main/java/app/zero/core/cloud/DriveAdapter.kt
@@ -3,5 +3,6 @@ package app.zero.core.cloud
 interface DriveAdapter {
     suspend fun ensureFolder(pathSegments: List<String>): Result<DriveFolderRef>
     suspend fun findBySha256(sha256: String, folderId: String): Result<DriveFileRef?>
+    suspend fun uploadResumable(spec: UploadSpec): Result<DriveFileRef>
     suspend fun probe(): Result<Unit>
 }

--- a/android-app/core/src/main/java/app/zero/core/cloud/DriveTypes.kt
+++ b/android-app/core/src/main/java/app/zero/core/cloud/DriveTypes.kt
@@ -2,6 +2,15 @@ package app.zero.core.cloud
 
 data class DriveFolderRef(val id: String)
 data class DriveFileRef(val id: String, val md5: String?, val bytes: Long?)
+data class UploadSpec(
+    val folderId: String,
+    val sha256: String,
+    val bytes: Long,
+    val mime: String,
+    val ext: String?,
+    val receivedAtUtc: String,
+    val idempotencyKey: String
+)
 sealed interface CloudAuthError {
     data class PermissionDeniedAuth(val reason: String): CloudAuthError
     data class UserCancelledAuth(val reason: String): CloudAuthError


### PR DESCRIPTION
## Summary
- extend DriveAdapter with resumable upload spec
- add CloudBinding entity/dao and database migration
- stub UploadWorker and scheduler for unique Drive uploads

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19308bf8083239e3e021f3c4388a3