### PR TITLE
Add VaultLogSurface module with basic markdown logging

### DIFF
--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -20,4 +20,4 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "InletTest0"
-include(":app", ":core")
+include(":app", ":core", ":vaultlogsurface")

--- a/android-app/vaultlogsurface/build.gradle.kts
+++ b/android-app/vaultlogsurface/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/android-app/vaultlogsurface/src/main/kotlin/com/example/vaultlog/EnvelopeNoteWriter.kt
+++ b/android-app/vaultlogsurface/src/main/kotlin/com/example/vaultlog/EnvelopeNoteWriter.kt
@@ -1,0 +1,44 @@
+package com.example.vaultlog
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+
+/**
+ * Writes pretty-printed envelope JSON into markdown notes.
+ */
+class EnvelopeNoteWriter(private val adapter: VaultAdapter) {
+    class Result(val path: Path)
+
+    /**
+     * Writes the envelope note if it does not already exist.
+     * Max size: 100 KiB.
+     */
+    suspend fun write(sha256: String, json: String): Result = withContext(Dispatchers.IO) {
+        val target = adapter.envelopeFileFor(sha256)
+        if (Files.exists(target)) return@withContext Result(target)
+
+        val content = """```json\n$json\n```\n"""
+        val bytes = content.toByteArray(Charsets.UTF_8)
+        require(bytes.size <= 100 * 1024) { "Envelope note exceeds 100 KiB" }
+
+        val tmp = Files.createTempFile(target.parent, sha256, ".tmp")
+        FileChannel.open(tmp, StandardOpenOption.WRITE).use { ch ->
+            ch.write(ByteBuffer.wrap(bytes))
+            ch.force(true)
+        }
+        try {
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE)
+        } catch (e: IOException) {
+            Files.deleteIfExists(tmp)
+            throw e
+        }
+        Result(target)
+    }
+}

--- a/android-app/vaultlogsurface/src/main/kotlin/com/example/vaultlog/LogWriter.kt
+++ b/android-app/vaultlogsurface/src/main/kotlin/com/example/vaultlog/LogWriter.kt
@@ -1,0 +1,59 @@
+package com.example.vaultlog
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Appends envelope entries to daily markdown log files.
+ */
+class LogWriter(private val adapter: VaultAdapter) {
+    data class Entry(val timestamp: Instant, val label: String, val sha256: String)
+
+    suspend fun append(entry: Entry): Path = withContext(Dispatchers.IO) {
+        if (entry.timestamp.atOffset(ZoneOffset.UTC).offset != ZoneOffset.UTC) {
+            throw IllegalArgumentException("Timestamp must be UTC")
+        }
+        val date = LocalDate.ofInstant(entry.timestamp, ZoneOffset.UTC)
+        val logFile = adapter.logFileFor(date)
+
+        val existing = if (Files.exists(logFile)) Files.readAllLines(logFile) else emptyList()
+        val frontMatterLines = mutableListOf(
+            "---",
+            "date: $date",
+            "generated_by: vault-log-surface@1.0.0",
+            "item_count: 0",
+            "---",
+        )
+        val entries = existing.drop(frontMatterLines.size).toMutableList()
+        if (entries.any { it.contains(entry.sha256) }) return@withContext logFile
+
+        val newLine = "- ${entry.timestamp} — [${entry.label}](../envelopes/${entry.sha256}.md)"
+        entries.add(newLine)
+        frontMatterLines[3] = "item_count: ${entries.size}"
+
+        val content = (frontMatterLines + entries).joinToString(System.lineSeparator()) + System.lineSeparator()
+
+        val tmp = Files.createTempFile(logFile.parent, logFile.fileName.toString(), ".tmp")
+        FileChannel.open(tmp, StandardOpenOption.WRITE).use { ch ->
+            ch.write(ByteBuffer.wrap(content.toByteArray(Charsets.UTF_8)))
+            ch.force(true)
+        }
+        try {
+            Files.move(tmp, logFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+        } catch (e: IOException) {
+            Files.deleteIfExists(tmp)
+            throw e
+        }
+        logFile
+    }
+}

--- a/android-app/vaultlogsurface/src/main/kotlin/com/example/vaultlog/VaultAdapter.kt
+++ b/android-app/vaultlogsurface/src/main/kotlin/com/example/vaultlog/VaultAdapter.kt
@@ -1,0 +1,16 @@
+package com.example.vaultlog
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Resolves directories inside an Obsidian vault for log and envelope storage.
+ * All paths are lazily created on demand.
+ */
+class VaultAdapter(private val vaultRoot: Path) {
+    val logsDir: Path = vaultRoot.resolve("logs").also { Files.createDirectories(it) }
+    val envelopesDir: Path = vaultRoot.resolve("envelopes").also { Files.createDirectories(it) }
+
+    fun logFileFor(date: java.time.LocalDate): Path = logsDir.resolve("$date.md")
+    fun envelopeFileFor(sha256: String): Path = envelopesDir.resolve("$sha256.md")
+}

--- a/android-app/vaultlogsurface/src/test/kotlin/com/example/vaultlog/LogSurfaceTest.kt
+++ b/android-app/vaultlogsurface/src/test/kotlin/com/example/vaultlog/LogSurfaceTest.kt
@@ -1,0 +1,55 @@
+package com.example.vaultlog
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class LogSurfaceTest {
+    private fun setup(): Triple<VaultAdapter, EnvelopeNoteWriter, LogWriter> {
+        val tmp = Files.createTempDirectory("vault")
+        val adapter = VaultAdapter(tmp)
+        val noteWriter = EnvelopeNoteWriter(adapter)
+        val logWriter = LogWriter(adapter)
+        return Triple(adapter, noteWriter, logWriter)
+    }
+
+    @Test
+    fun `duplicate envelopes collapse`() = runBlocking {
+        val (adapter, noteWriter, logWriter) = setup()
+        val sha = "abc123"
+        noteWriter.write(sha, "{\"type\":\"camera\"}")
+        val ts = Instant.parse("2025-09-10T08:52:00Z")
+        val entry = LogWriter.Entry(ts, "camera", sha)
+        logWriter.append(entry)
+        logWriter.append(entry)
+        val logFile = adapter.logFileFor(LocalDate.of(2025, 9, 10))
+        val lines = Files.readAllLines(logFile)
+        assertEquals(1, lines.count { it.contains(sha) })
+    }
+
+    @Test
+    fun `new day rotates file`() = runBlocking {
+        val (adapter, noteWriter, logWriter) = setup()
+        noteWriter.write("a1", "{}"); logWriter.append(LogWriter.Entry(Instant.parse("2025-09-10T23:59:00Z"), "x", "a1"))
+        noteWriter.write("a2", "{}"); logWriter.append(LogWriter.Entry(Instant.parse("2025-09-11T00:00:10Z"), "x", "a2"))
+        assertTrue(Files.exists(adapter.logFileFor(LocalDate.of(2025,9,10))))
+        assertTrue(Files.exists(adapter.logFileFor(LocalDate.of(2025,9,11))))
+    }
+
+    @Test
+    fun `log links to envelope note`() = runBlocking {
+        val (adapter, noteWriter, logWriter) = setup()
+        val sha = "abc123"
+        noteWriter.write(sha, "{}");
+        val ts = Instant.parse("2025-09-10T08:52:00Z")
+        logWriter.append(LogWriter.Entry(ts, "camera", sha))
+        val logFile = adapter.logFileFor(LocalDate.of(2025,9,10))
+        val lines = Files.readAllLines(logFile)
+        assertTrue(lines.any { it.contains("../envelopes/$sha.md") })
+    }
+}


### PR DESCRIPTION
## Summary
- add VaultLogSurface module with VaultAdapter, EnvelopeNoteWriter, and LogWriter to emit markdown logs and envelope notes
- include unit tests covering duplicate collapse, daily rotation, and log-to-envelope linking

## Testing
- `./gradlew :vaultlogsurface:test`

------
https://chatgpt.com/codex/tasks/task_e_68c194d7014483238de3c5eeaaf3775a