### PR TITLE
Add Drive reconciler worker skeleton and DAO utilities

### DIFF
--- a/android-app/app/src/main/java/com/mfme/kernel/data/Dao.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/Dao.kt
@@ -16,4 +16,7 @@ interface EnvelopeDao {
 
     @Query("SELECT * FROM envelopes ORDER BY receivedAtUtc DESC")
     fun observeAll(): Flow<List<Envelope>>
+
+    @Query("SELECT * FROM envelopes")
+    suspend fun getAll(): List<Envelope>
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/data/cloud/CloudBindingDao.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/cloud/CloudBindingDao.kt
@@ -10,9 +10,21 @@ interface CloudBindingDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(binding: CloudBinding): Long
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(binding: CloudBinding): Long
+
     @Query("SELECT * FROM cloud_binding WHERE envelopeId = :envelopeId")
     suspend fun findByEnvelopeId(envelopeId: Long): CloudBinding?
 
     @Query("SELECT * FROM cloud_binding WHERE driveFileId = :driveFileId")
     suspend fun findByDriveFileId(driveFileId: String): CloudBinding?
+
+    @Query("DELETE FROM cloud_binding WHERE envelopeId = :envelopeId")
+    suspend fun deleteByEnvelopeId(envelopeId: Long)
+
+    @Query("SELECT * FROM cloud_binding")
+    suspend fun getAll(): List<CloudBinding>
+
+    @Query("SELECT cb.* FROM cloud_binding cb LEFT JOIN envelopes e ON cb.envelopeId = e.id WHERE e.id IS NULL")
+    suspend fun findOrphans(): List<CloudBinding>
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/telemetry/TelemetryCode.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/telemetry/TelemetryCode.kt
@@ -13,6 +13,14 @@ sealed interface TelemetryCode {
     override val ok = true
     override val wire = "ok_duplicate"
   }
+  data object OkRebound : TelemetryCode {
+    override val ok = true
+    override val wire = "ok_rebound"
+  }
+  data object OkAlreadyBound : TelemetryCode {
+    override val ok = true
+    override val wire = "ok_already_bound"
+  }
 
   // Errors
   data object PermissionDenied : TelemetryCode {
@@ -38,6 +46,10 @@ sealed interface TelemetryCode {
   data object DigestMismatch : TelemetryCode {
     override val ok = false
     override val wire = "digest_mismatch"
+  }
+  data object ErrorNotFound : TelemetryCode {
+    override val ok = false
+    override val wire = "error_not_found"
   }
   data class Unknown(val name: String = "unknown") : TelemetryCode {
     override val ok = false

--- a/android-app/app/src/main/java/com/mfme/kernel/work/ReconcilerScheduler.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/work/ReconcilerScheduler.kt
@@ -1,0 +1,29 @@
+package com.mfme.kernel.work
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+/**
+ * Schedules the daily [ReconcilerWorker] with exponential backoff.
+ */
+object ReconcilerScheduler {
+    private const val UNIQUE_NAME = "reconciler_daily"
+
+    fun schedule(context: Context) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.UNMETERED)
+            .build()
+        val work = PeriodicWorkRequestBuilder<ReconcilerWorker>(1, TimeUnit.DAYS)
+            .setConstraints(constraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.HOURS)
+            .build()
+        WorkManager.getInstance(context)
+            .enqueueUniquePeriodicWork(UNIQUE_NAME, ExistingPeriodicWorkPolicy.KEEP, work)
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/work/ReconcilerWorker.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/work/ReconcilerWorker.kt
@@ -1,0 +1,64 @@
+package com.mfme.kernel.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import app.zero.core.cloud.DriveAdapter
+import com.mfme.kernel.data.KernelDatabase
+import com.mfme.kernel.data.cloud.CloudBinding
+import com.mfme.kernel.di.AppModule
+import com.mfme.kernel.telemetry.ReceiptEmitter
+import com.mfme.kernel.telemetry.TelemetryCode
+import java.time.Instant
+
+/**
+ * Periodic worker that verifies cloud bindings against remote Drive state.
+ * TODO: inject real DriveAdapter implementation.
+ */
+class ReconcilerWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val db: KernelDatabase = AppModule.provideDatabase(applicationContext)
+        val emitter: ReceiptEmitter = AppModule.provideReceiptEmitter(applicationContext, db)
+        val span = emitter.begin("reconciler")
+        val envelopeDao = db.envelopeDao()
+        val bindingDao = db.cloudBindingDao()
+        val drive: DriveAdapter = driveAdapter()
+
+        // Tombstone orphan bindings
+        bindingDao.findOrphans().forEach { bindingDao.deleteByEnvelopeId(it.envelopeId) }
+
+        val envelopes = envelopeDao.getAll()
+        for (env in envelopes) {
+            val binding = bindingDao.findByEnvelopeId(env.id)
+            if (binding == null) {
+                val ref = drive.findBySha256(env.sha256, "").getOrNull()
+                if (ref != null) {
+                    val newBinding = CloudBinding(env.id, ref.id, Instant.now(), ref.md5, ref.bytes)
+                    bindingDao.upsert(newBinding)
+                    emitter.emitV2(true, TelemetryCode.OkRebound.wire, "reconciler", span.spanId, env.id, env.sha256, null)
+                } else {
+                    emitter.emitV2(false, TelemetryCode.ErrorNotFound.wire, "reconciler", span.spanId, env.id, env.sha256, null)
+                }
+            } else {
+                val meta = drive.getMetadata(binding.driveFileId).getOrNull()
+                if (meta == null) {
+                    val ref = drive.findBySha256(env.sha256, "").getOrNull()
+                    if (ref != null) {
+                        val rebound = CloudBinding(env.id, ref.id, Instant.now(), ref.md5, ref.bytes)
+                        bindingDao.upsert(rebound)
+                        emitter.emitV2(true, TelemetryCode.OkRebound.wire, "reconciler", span.spanId, env.id, env.sha256, null)
+                    } else {
+                        emitter.emitV2(false, TelemetryCode.ErrorNotFound.wire, "reconciler", span.spanId, env.id, env.sha256, null)
+                    }
+                } else {
+                    emitter.emitV2(true, TelemetryCode.OkAlreadyBound.wire, "reconciler", span.spanId, env.id, env.sha256, null)
+                }
+            }
+        }
+
+        emitter.end(span)
+        return Result.success()
+    }
+
+    private suspend fun driveAdapter(): DriveAdapter = TODO("Provide DriveAdapter")
+}

--- a/android-app/core/src/main/java/app/zero/core/cloud/DriveAdapter.kt
+++ b/android-app/core/src/main/java/app/zero/core/cloud/DriveAdapter.kt
@@ -3,6 +3,7 @@ package app.zero.core.cloud
 interface DriveAdapter {
     suspend fun ensureFolder(pathSegments: List<String>): Result<DriveFolderRef>
     suspend fun findBySha256(sha256: String, folderId: String): Result<DriveFileRef?>
+    suspend fun getMetadata(fileId: String): Result<DriveFileRef?>
     suspend fun uploadResumable(spec: UploadSpec): Result<DriveFileRef>
     suspend fun probe(): Result<Unit>
 }


### PR DESCRIPTION
## Summary
- extend telemetry codes for drive reconciliation
- add DAO helpers and drive adapter metadata fetch
- scaffold daily ReconcilerWorker with scheduler

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c197564ae8832390776d83c74a5bcb