### PR TITLE
Add SMS inlet and envelope archiving

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
     <application
         android:allowBackup="true"
         android:label="@string/app_name"
@@ -35,5 +38,12 @@
                 <data android:mimeType="*/*" />
             </intent-filter>
         </activity>
+        <receiver
+            android:name="com.mfme.kernel.adapters.sms.SmsReceiveAdapter"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/android-app/app/src/main/java/com/mfme/kernel/adapters/sms/SmsReceiveAdapter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/adapters/sms/SmsReceiveAdapter.kt
@@ -1,0 +1,28 @@
+package com.mfme.kernel.adapters.sms
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Telephony
+import com.mfme.kernel.ServiceLocator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.time.Instant
+
+/**
+ * BroadcastReceiver that ingests incoming SMS messages into the repository.
+ */
+class SmsReceiveAdapter : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
+        val repo = ServiceLocator.repository(context.applicationContext)
+        val scope = CoroutineScope(Dispatchers.IO)
+        messages?.forEach { msg ->
+            val sender = msg.displayOriginatingAddress ?: return@forEach
+            val body = msg.displayMessageBody ?: return@forEach
+            val ts = Instant.ofEpochMilli(msg.timestampMillis)
+            scope.launch { repo.ingestSmsIn(sender, body, ts) }
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/adapters/sms/SmsSendAdapter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/adapters/sms/SmsSendAdapter.kt
@@ -1,0 +1,27 @@
+package com.mfme.kernel.adapters.sms
+
+import android.content.Context
+import android.telephony.SmsManager
+import com.mfme.kernel.data.KernelRepository
+import com.mfme.kernel.data.SaveResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+
+/**
+ * Simple SMS sending adapter that delegates persistence to the repository
+ * before handing off to the platform's [SmsManager].
+ */
+class SmsSendAdapter(
+    private val appContext: Context,
+    private val repo: KernelRepository,
+    private val smsManager: SmsManager = SmsManager.getDefault()
+) {
+    suspend fun send(phone: String, body: String): SaveResult = withContext(Dispatchers.IO) {
+        require(phone.isNotBlank()) { "empty_phone" }
+        require(body.isNotBlank()) { "empty_body" }
+        val result = repo.saveSmsOut(phone, body, Instant.now())
+        smsManager.sendTextMessage(phone, null, body, null, null)
+        result
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/data/KernelRepository.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/KernelRepository.kt
@@ -4,7 +4,7 @@ import com.mfme.kernel.adapters.share.SharePayload
 import com.mfme.kernel.data.telemetry.ReceiptEntity
 import kotlinx.coroutines.flow.Flow
 
-interface KernelRepository {
+interface KernelRepository : KernelRepositorySms {
     suspend fun saveEnvelope(env: Envelope): SaveResult
     suspend fun saveFromShare(payload: SharePayload): SaveResult
     suspend fun saveFromCamera(bytes: ByteArray, meta: Map<String, Any?>): SaveResult

--- a/android-app/app/src/main/java/com/mfme/kernel/data/KernelRepositorySms.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/data/KernelRepositorySms.kt
@@ -1,0 +1,8 @@
+package com.mfme.kernel.data
+
+import java.time.Instant
+
+interface KernelRepositorySms {
+    suspend fun saveSmsOut(phone: String, body: String, sentAtUtc: Instant): SaveResult
+    suspend fun ingestSmsIn(sender: String, body: String, receivedAtUtc: Instant): SaveResult
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/di/AppModule.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/di/AppModule.kt
@@ -11,6 +11,8 @@ import com.mfme.kernel.data.MIGRATION_3_4
 import com.mfme.kernel.telemetry.ErrorEmitter
 import com.mfme.kernel.telemetry.NdjsonSink
 import com.mfme.kernel.telemetry.ReceiptEmitter
+import com.mfme.kernel.export.EnvelopeChainer
+import com.mfme.kernel.export.ObsidianExporter
 import kotlinx.coroutines.Dispatchers
 
 object AppModule {
@@ -27,11 +29,18 @@ object AppModule {
     fun provideErrorEmitter(receiptEmitter: ReceiptEmitter): ErrorEmitter =
         ErrorEmitter(receiptEmitter)
 
+    fun provideEnvelopeChainer(context: Context): EnvelopeChainer {
+        val exporter = ObsidianExporter()
+        return EnvelopeChainer(context, exporter)
+    }
+
     fun provideRepository(
         context: Context,
         db: KernelDatabase,
         emitter: ReceiptEmitter,
         errorEmitter: ErrorEmitter
-    ): KernelRepository =
-        KernelRepositoryImpl(context, db, Dispatchers.IO, emitter, errorEmitter, db.spanDao())
+    ): KernelRepository {
+        val chainer = provideEnvelopeChainer(context)
+        return KernelRepositoryImpl(context, db, Dispatchers.IO, emitter, errorEmitter, db.spanDao(), chainer)
+    }
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/export/EnvelopeChainer.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/export/EnvelopeChainer.kt
@@ -1,0 +1,30 @@
+package com.mfme.kernel.export
+
+import android.content.Context
+import com.mfme.kernel.data.Envelope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Minimal envelope chainer that logs envelope hashes and mirrors
+ * them into an optional Obsidian vault. This implementation is
+ * intentionally simple for the exercise and does not attempt to
+ * replicate the full MFME behavior.
+ */
+class EnvelopeChainer(
+    private val appContext: Context,
+    private val exporter: ObsidianExporter = ObsidianExporter()
+) {
+    suspend fun chain(env: Envelope) = withContext(Dispatchers.IO) {
+        val dir = File(appContext.filesDir, "telemetry").apply { mkdirs() }
+        val log = File(dir, "envelopes.ndjson")
+        FileOutputStream(log, true).use { fos ->
+            fos.write(env.sha256.toByteArray())
+            fos.write('\n'.code)
+            fos.fd.sync()
+        }
+        exporter.export(env)
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/export/ObsidianExporter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/export/ObsidianExporter.kt
@@ -1,0 +1,20 @@
+package com.mfme.kernel.export
+
+import com.mfme.kernel.data.Envelope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+
+/** Simple exporter that mirrors envelopes into an Obsidian vault if configured. */
+class ObsidianExporter(private val root: File? = null) {
+    suspend fun export(env: Envelope) = withContext(Dispatchers.IO) {
+        val rootDir = root ?: return@withContext
+        val dir = File(rootDir, "envelopes").apply { mkdirs() }
+        val file = File(dir, "${env.sha256}.md")
+        FileOutputStream(file).use { fos ->
+            fos.write("# Envelope ${env.sha256}\n".toByteArray())
+            fos.fd.sync()
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/CaptureScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/CaptureScreen.kt
@@ -91,6 +91,16 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                         .padding(horizontal = 16.dp)
                 ) { Text("Sensors") }
             }
+            item {
+                Button(
+                    onClick = {
+                        viewModel.saveSmsOut("1234567890", "hi", ::handleResult)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                ) { Text("SMS") }
+            }
         }
     }
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/HistoryScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/HistoryScreen.kt
@@ -29,6 +29,7 @@ fun HistoryScreen(viewModel: KernelViewModel) {
     val filtered = when (filter) {
         1 -> receipts.filter { !it.ok }
         2 -> receipts.filter { it.ok }
+        3 -> receipts.filter { it.adapter == "sms_in" || it.adapter == "sms_out" }
         else -> receipts
     }
 
@@ -42,6 +43,7 @@ fun HistoryScreen(viewModel: KernelViewModel) {
                 TextButton(onClick = { filter = 0 }) { Text("All") }
                 TextButton(onClick = { filter = 1 }) { Text("Errors") }
                 TextButton(onClick = { filter = 2 }) { Text("Ok") }
+                TextButton(onClick = { filter = 3 }) { Text("SMS") }
             }
         }
         items(filtered, key = { it.id }) { r ->

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/KernelViewModel.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/KernelViewModel.kt
@@ -36,4 +36,12 @@ class KernelViewModel(private val repo: KernelRepository): ViewModel() {
     fun saveFromSensors(json: String, onDone: (SaveResult) -> Unit = {}) {
         viewModelScope.launch { onDone(repo.saveFromSensors(json)) }
     }
+
+    fun saveSmsOut(phone: String, body: String, onDone: (SaveResult) -> Unit = {}) {
+        viewModelScope.launch { onDone(repo.saveSmsOut(phone, body, java.time.Instant.now())) }
+    }
+
+    fun ingestSmsIn(sender: String, body: String, onDone: (SaveResult) -> Unit = {}) {
+        viewModelScope.launch { onDone(repo.ingestSmsIn(sender, body, java.time.Instant.now())) }
+    }
 }


### PR DESCRIPTION
## Summary
- Support SMS send/receive with new adapters and manifest permissions
- Extend repository for `sms_in`/`sms_out` envelopes and hook into envelope chainer
- Minimal chainer + Obsidian exporter and UI filters for SMS history

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1995ad1e883239482323030f92506