### PR TITLE
Scaffold modular kernel UI with theme, panel host, and stubs

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    testImplementation(libs.androidx.ui.test.junit4)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
 

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/AboutScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/AboutScreen.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import com.mfme.kernel.R
+import com.mfme.kernel.ui.theme.KernelTheme
 
 @Composable
 fun AboutScreen() {
@@ -22,7 +22,7 @@ fun AboutScreen() {
         text = text,
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(KernelTheme.tokens.spacing.md)
             .verticalScroll(rememberScrollState())
     )
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/CaptureScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/CaptureScreen.kt
@@ -15,7 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import com.mfme.kernel.ui.theme.KernelTheme
+import com.mfme.kernel.ui.gestures.CaptureCardDemo
 import kotlinx.coroutines.launch
 import java.time.Instant
 import com.mfme.kernel.data.SaveResult
@@ -33,13 +34,15 @@ fun CaptureScreen(viewModel: KernelViewModel) {
         scope.launch { snackbarHostState.showSnackbar(msg, duration = SnackbarDuration.Short) }
     }
 
+    val tokens = KernelTheme.tokens
     Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { paddingValues ->
         LazyColumn(
             modifier = Modifier
                 .padding(paddingValues)
                 .fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(tokens.spacing.sm)
         ) {
+            item { CaptureCardDemo(viewModel) }
             item {
                 Button(
                     onClick = {
@@ -47,7 +50,7 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = tokens.spacing.md)
                 ) { Text("Camera") }
             }
             item {
@@ -57,7 +60,7 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = tokens.spacing.md)
                 ) { Text("Mic") }
             }
             item {
@@ -68,7 +71,7 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = tokens.spacing.md)
                 ) { Text("Files") }
             }
             item {
@@ -78,7 +81,7 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = tokens.spacing.md)
                 ) { Text("Location") }
             }
             item {
@@ -88,7 +91,7 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = tokens.spacing.md)
                 ) { Text("Sensors") }
             }
             item {
@@ -98,7 +101,7 @@ fun CaptureScreen(viewModel: KernelViewModel) {
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                        .padding(horizontal = tokens.spacing.md)
                 ) { Text("SMS") }
             }
         }

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/HistoryScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/HistoryScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -20,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import com.mfme.kernel.ui.theme.KernelTheme
 @Composable
 fun HistoryScreen(viewModel: KernelViewModel) {
     val receipts by viewModel.receipts.collectAsState()
@@ -33,12 +33,14 @@ fun HistoryScreen(viewModel: KernelViewModel) {
         else -> receipts
     }
 
+    val tokens = KernelTheme.tokens
     LazyColumn(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        modifier = Modifier.fillMaxSize().padding(tokens.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(tokens.spacing.sm)
     ) {
         item {
-            Text("Receipts", style = MaterialTheme.typography.titleMedium)
+            val tokens = KernelTheme.tokens
+            Text("Receipts", style = tokens.typeScale.title)
             Column(horizontalAlignment = Alignment.Start) {
                 TextButton(onClick = { filter = 0 }) { Text("All") }
                 TextButton(onClick = { filter = 1 }) { Text("Errors") }
@@ -54,8 +56,11 @@ fun HistoryScreen(viewModel: KernelViewModel) {
                 r.message?.let { Text(it) }
             }
         }
-        item { Spacer(modifier = Modifier.height(24.dp)) }
-        item { Text("Envelopes", style = MaterialTheme.typography.titleMedium) }
+        item { Spacer(modifier = Modifier.height(tokens.spacing.lg)) }
+        item {
+            val tokens = KernelTheme.tokens
+            Text("Envelopes", style = tokens.typeScale.title)
+        }
         items(envelopes, key = { it.id }) { e ->
             Column {
                 Text("sha256: ${e.sha256}")

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/KernelActivity.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/KernelActivity.kt
@@ -3,31 +3,16 @@ package com.mfme.kernel.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
 import com.mfme.kernel.ServiceLocator
+import com.mfme.kernel.ui.panels.PluginPanelHost
+import com.mfme.kernel.ui.panels.registerBuiltinPanels
+import com.mfme.kernel.ui.theme.KernelTheme
 
 class KernelActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -47,46 +32,8 @@ fun KernelApp() {
         }
     })
 
-    val navController = rememberNavController()
-    val items = listOf(
-        NavItem("capture", "Capture", Icons.Filled.CameraAlt),
-        NavItem("history", "History", Icons.Filled.History),
-        NavItem("about", "About", Icons.Filled.Info)
-    )
-
-    MaterialTheme {
-        Scaffold(
-            bottomBar = {
-                NavigationBar {
-                    val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
-                    items.forEach { item ->
-                        NavigationBarItem(
-                            selected = currentRoute == item.route,
-                            onClick = {
-                                navController.navigate(item.route) {
-                                    popUpTo(navController.graph.startDestinationId) { saveState = true }
-                                    launchSingleTop = true
-                                    restoreState = true
-                                }
-                            },
-                            icon = { Icon(item.icon, contentDescription = item.label) },
-                            label = { Text(item.label) }
-                        )
-                    }
-                }
-            }
-        ) { innerPadding ->
-            NavHost(
-                navController = navController,
-                startDestination = "capture",
-                modifier = Modifier.padding(innerPadding)
-            ) {
-                composable("capture") { CaptureScreen(viewModel) }
-                composable("history") { HistoryScreen(viewModel) }
-                composable("about") { AboutScreen() }
-            }
-        }
+    registerBuiltinPanels(viewModel)
+    KernelTheme {
+        PluginPanelHost()
     }
 }
-
-data class NavItem(val route: String, val label: String, val icon: ImageVector)

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/CaptureCard.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/CaptureCard.kt
@@ -1,0 +1,29 @@
+package com.mfme.kernel.ui.gestures
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.mfme.kernel.ui.KernelViewModel
+import com.mfme.kernel.ui.theme.KernelTheme
+
+/** Demo card showing long-press memo toggling. */
+@Composable
+fun CaptureCardDemo(viewModel: KernelViewModel) {
+    var memo by remember { mutableStateOf(false) }
+    val adapter = remember(viewModel) {
+        GestureAdapter { intent ->
+            if (intent is GestureIntent.MemoStart) memo = !memo
+            NoopGestureAdapter(viewModel).on(intent)
+        }
+    }
+    val tokens = KernelTheme.tokens
+    Card(modifier = Modifier.padding(tokens.spacing.md).mfmeGestures(adapter)) {
+        Text(if (memo) "memo…" else "long press")
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/GestureAdapter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/GestureAdapter.kt
@@ -1,0 +1,6 @@
+package com.mfme.kernel.ui.gestures
+
+/** Adapter receiving gesture intents. */
+fun interface GestureAdapter {
+    fun on(intent: GestureIntent)
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/GestureIntent.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/GestureIntent.kt
@@ -1,0 +1,9 @@
+package com.mfme.kernel.ui.gestures
+
+/** High level gestures the UI cares about. */
+sealed class GestureIntent {
+    object Mark : GestureIntent()
+    object MemoStart : GestureIntent()
+    object MemoStop : GestureIntent()
+    data class Navigate(val panelId: String) : GestureIntent()
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/GesturesModifier.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/GesturesModifier.kt
@@ -1,0 +1,22 @@
+package com.mfme.kernel.ui.gestures
+
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+
+/** Binds basic MFME gestures to the supplied adapter. */
+fun Modifier.mfmeGestures(adapter: GestureAdapter): Modifier =
+    pointerInput(adapter) {
+        detectTapGestures(
+            onTap = { adapter.on(GestureIntent.Mark) },
+            onLongPress = { adapter.on(GestureIntent.MemoStart) }
+        )
+    }
+    .pointerInput(adapter) {
+        detectHorizontalDragGestures { change, dragAmount ->
+            change.consume()
+            val id = if (dragAmount > 0) "right" else "left"
+            adapter.on(GestureIntent.Navigate(id))
+        }
+    }

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/NoopGestureAdapter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/gestures/NoopGestureAdapter.kt
@@ -1,0 +1,20 @@
+package com.mfme.kernel.ui.gestures
+
+import com.mfme.kernel.ui.KernelViewModel
+
+/** Simple adapter that records gesture receipts through the ViewModel. */
+class NoopGestureAdapter(
+    private val viewModel: KernelViewModel,
+    private val windowMs: Long = 300,
+    private val nowMs: () -> Long = { System.currentTimeMillis() }
+) : GestureAdapter {
+    private var lastTap = 0L
+    override fun on(intent: GestureIntent) {
+        if (intent == GestureIntent.Mark) {
+            val now = nowMs()
+            if (now - lastTap < windowMs) return
+            lastTap = now
+        }
+        viewModel.logGesture(intent)
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/lab/OperatorLabPanel.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/lab/OperatorLabPanel.kt
@@ -1,0 +1,37 @@
+package com.mfme.kernel.ui.lab
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.mfme.kernel.ui.KernelViewModel
+import com.mfme.kernel.ui.gestures.GestureIntent
+import com.mfme.kernel.ui.theme.KernelTheme
+
+/** Developer sandbox panel for operator experiments. */
+@Composable
+fun OperatorLabPanel(viewModel: KernelViewModel) {
+    var timeline by remember { mutableStateOf(false) }
+    var haptic by remember { mutableStateOf(0.5f) }
+    val tokens = KernelTheme.tokens
+    Column(Modifier.fillMaxSize().padding(tokens.spacing.md)) {
+        Text("Operator Lab")
+        Switch(checked = timeline, onCheckedChange = {
+            timeline = it
+            viewModel.logGesture(GestureIntent.Mark)
+        })
+        Slider(value = haptic, onValueChange = {
+            haptic = it
+            viewModel.logGesture(GestureIntent.Mark)
+        })
+        Text("timeline=$timeline haptic=$haptic")
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/log/DevNullVaultWriter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/log/DevNullVaultWriter.kt
@@ -1,0 +1,8 @@
+package com.mfme.kernel.ui.log
+
+import java.time.LocalDate
+
+/** Preview only writer that discards all output. */
+class DevNullVaultWriter : VaultWriterPort {
+    override suspend fun write(day: LocalDate, text: String): VaultWriteResult = VaultWriteResult.OkPreviewOnly
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/log/LogSurfacePanel.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/log/LogSurfacePanel.kt
@@ -1,0 +1,63 @@
+package com.mfme.kernel.ui.log
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.mfme.kernel.data.Envelope
+import com.mfme.kernel.data.telemetry.ReceiptEntity
+import com.mfme.kernel.ui.KernelViewModel
+import com.mfme.kernel.ui.theme.KernelTheme
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/** Builds a markdown preview from receipts and envelopes. */
+fun buildMarkdownPreview(receipts: List<ReceiptEntity>, envelopes: List<Envelope>): String {
+    val date = LocalDate.now(ZoneOffset.UTC)
+    val sb = StringBuilder("# ${date}\n")
+    receipts.forEach { r ->
+        sb.append("- receipt ${r.code} ${r.tsUtcIso}\n")
+    }
+    envelopes.forEach { e ->
+        sb.append("- envelope ${e.sha256}\n")
+    }
+    return sb.toString()
+}
+
+/** Panel showing recent receipts/envelopes with a markdown preview. */
+@Composable
+fun LogSurfacePanel(viewModel: KernelViewModel) {
+    val receipts by viewModel.receipts.collectAsState()
+    val envelopes by viewModel.envelopes.collectAsState()
+    var show by remember { mutableStateOf(false) }
+    val preview = remember(receipts, envelopes) { buildMarkdownPreview(receipts, envelopes) }
+
+    val tokens = KernelTheme.tokens
+    Column(Modifier.fillMaxSize().padding(tokens.spacing.md), verticalArrangement = Arrangement.spacedBy(tokens.spacing.sm)) {
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(receipts, key = { it.id }) { r ->
+                Text("${r.code} · ${r.adapter}")
+            }
+            items(envelopes, key = { it.id }) { e ->
+                Text("env ${e.sha256}")
+            }
+        }
+        Button(onClick = { show = !show }) { Text("Preview Markdown") }
+        if (show) {
+            Text(preview)
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/log/VaultWriterPort.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/log/VaultWriterPort.kt
@@ -1,0 +1,12 @@
+package com.mfme.kernel.ui.log
+
+import java.time.LocalDate
+
+sealed class VaultWriteResult {
+    object OkPreviewOnly : VaultWriteResult()
+}
+
+/** Port for writing markdown logs to a vault. */
+interface VaultWriterPort {
+    suspend fun write(day: LocalDate, text: String): VaultWriteResult
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PanelDescriptor.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PanelDescriptor.kt
@@ -1,0 +1,12 @@
+package com.mfme.kernel.ui.panels
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/** Description of a panel provided to the host. */
+data class PanelDescriptor(
+    val id: String,
+    val title: String,
+    val icon: ImageVector?,
+    val content: @Composable () -> Unit
+)

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PanelRegistry.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PanelRegistry.kt
@@ -1,0 +1,14 @@
+package com.mfme.kernel.ui.panels
+
+/** In-memory registry for panels. */
+object PanelRegistry {
+    private val panels = LinkedHashMap<String, PanelDescriptor>()
+
+    fun register(descriptor: PanelDescriptor) {
+        panels[descriptor.id] = descriptor
+    }
+
+    fun all(): List<PanelDescriptor> = panels.values.toList()
+    fun byId(id: String): PanelDescriptor? = panels[id]
+    fun clear() { panels.clear() }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PanelsBuiltin.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PanelsBuiltin.kt
@@ -1,0 +1,58 @@
+package com.mfme.kernel.ui.panels
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.mfme.kernel.ui.AboutScreen
+import com.mfme.kernel.ui.CaptureScreen
+import com.mfme.kernel.ui.HistoryScreen
+import com.mfme.kernel.ui.KernelViewModel
+import com.mfme.kernel.ui.log.LogSurfacePanel
+import com.mfme.kernel.ui.lab.OperatorLabPanel
+
+/** Registers built-in panels used by the kernel shell. */
+fun registerBuiltinPanels(viewModel: KernelViewModel, devMode: Boolean = true) {
+    PanelRegistry.clear()
+    PanelRegistry.register(
+        PanelDescriptor("capture", "Capture", Icons.Filled.CameraAlt) {
+            CaptureScreen(viewModel)
+        }
+    )
+    PanelRegistry.register(
+        PanelDescriptor("history", "History", Icons.Filled.History) {
+            HistoryScreen(viewModel)
+        }
+    )
+    PanelRegistry.register(
+        PanelDescriptor("cloud", "Cloud", Icons.Filled.Cloud) {
+            Text("Cloud")
+        }
+    )
+    PanelRegistry.register(
+        PanelDescriptor("settings", "Settings", Icons.Filled.Settings) {
+            AboutScreen()
+        }
+    )
+    PanelRegistry.register(
+        PanelDescriptor("log", "Log", Icons.Filled.Info) {
+            LogSurfacePanel(viewModel)
+        }
+    )
+    if (devMode) {
+        PanelRegistry.register(
+            PanelDescriptor("lab", "Lab", Icons.Filled.Info) {
+                OperatorLabPanel(viewModel)
+            }
+        )
+    }
+    PanelRegistry.register(
+        PanelDescriptor("hello", "Hello", null) {
+            Text("Hello Plugin")
+        }
+    )
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PluginPanelHost.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PluginPanelHost.kt
@@ -1,0 +1,43 @@
+package com.mfme.kernel.ui.panels
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+/** Host composable that displays panels registered in [PanelRegistry]. */
+@Composable
+fun PluginPanelHost() {
+    val panels = remember { PanelRegistry.all() }
+    var activeId by rememberSaveable { mutableStateOf(panels.firstOrNull()?.id ?: "") }
+    val active = panels.firstOrNull { it.id == activeId }
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                panels.forEach { panel ->
+                    NavigationBarItem(
+                        selected = panel.id == activeId,
+                        onClick = { activeId = panel.id },
+                        icon = { panel.icon?.let { Icon(it, contentDescription = panel.title) } },
+                        label = { Text(panel.title) }
+                    )
+                }
+            }
+        }
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding)) {
+            active?.content?.invoke()
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/theme/MinimalTheme.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/theme/MinimalTheme.kt
@@ -1,0 +1,94 @@
+package com.mfme.kernel.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
+
+private val lightTokens = ThemeTokens(
+    colors = ThemeColors(
+        primary = Color(0xFF0061A4),
+        secondary = Color(0xFF005CB2),
+        background = Color(0xFFFFFFFF),
+        surface = Color(0xFFFFFFFF),
+        onPrimary = Color.White,
+        onSecondary = Color.White,
+        onBackground = Color.Black,
+        onSurface = Color.Black
+    ),
+    typeScale = ThemeTypeScale(
+        body = TextStyle(fontSize = 16.sp),
+        title = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Medium),
+        label = TextStyle(fontSize = 14.sp)
+    )
+)
+
+private val darkTokens = ThemeTokens(
+    colors = ThemeColors(
+        primary = Color(0xFF9CD3FF),
+        secondary = Color(0xFF9CCBFF),
+        background = Color(0xFF000000),
+        surface = Color(0xFF1E1E1E),
+        onPrimary = Color.Black,
+        onSecondary = Color.Black,
+        onBackground = Color.White,
+        onSurface = Color.White
+    ),
+    typeScale = ThemeTypeScale(
+        body = TextStyle(fontSize = 16.sp),
+        title = TextStyle(fontSize = 20.sp, fontWeight = FontWeight.Medium),
+        label = TextStyle(fontSize = 14.sp)
+    )
+)
+
+private val LocalThemeTokens = staticCompositionLocalOf { lightTokens }
+
+@Composable
+fun KernelTheme(useDarkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+    val tokens = if (useDarkTheme) darkTokens else lightTokens
+    val colorScheme = if (useDarkTheme) {
+        darkColorScheme(
+            primary = tokens.colors.primary,
+            secondary = tokens.colors.secondary,
+            background = tokens.colors.background,
+            surface = tokens.colors.surface,
+            onPrimary = tokens.colors.onPrimary,
+            onSecondary = tokens.colors.onSecondary,
+            onBackground = tokens.colors.onBackground,
+            onSurface = tokens.colors.onSurface,
+        )
+    } else {
+        lightColorScheme(
+            primary = tokens.colors.primary,
+            secondary = tokens.colors.secondary,
+            background = tokens.colors.background,
+            surface = tokens.colors.surface,
+            onPrimary = tokens.colors.onPrimary,
+            onSecondary = tokens.colors.onSecondary,
+            onBackground = tokens.colors.onBackground,
+            onSurface = tokens.colors.onSurface,
+        )
+    }
+    val typography = Typography(
+        bodyLarge = tokens.typeScale.body,
+        titleMedium = tokens.typeScale.title,
+        labelMedium = tokens.typeScale.label,
+    )
+    CompositionLocalProvider(LocalThemeTokens provides tokens) {
+        MaterialTheme(colorScheme = colorScheme, typography = typography, content = content)
+    }
+}
+
+object KernelTheme {
+    val tokens: ThemeTokens
+        @Composable get() = LocalThemeTokens.current
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/theme/ThemeAdapter.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/theme/ThemeAdapter.kt
@@ -1,0 +1,6 @@
+package com.mfme.kernel.ui.theme
+
+/** Provides theme tokens. */
+interface ThemeAdapter {
+    val tokens: ThemeTokens
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/theme/ThemePreviewScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/theme/ThemePreviewScreen.kt
@@ -1,0 +1,41 @@
+package com.mfme.kernel.ui.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/** Simple screen that previews theme tokens. */
+@Composable
+fun ThemePreviewScreen() {
+    val t = KernelTheme.tokens
+    val colors = listOf(
+        "primary" to t.colors.primary,
+        "secondary" to t.colors.secondary,
+        "background" to t.colors.background,
+        "surface" to t.colors.surface,
+        "onPrimary" to t.colors.onPrimary,
+        "onSecondary" to t.colors.onSecondary,
+        "onBackground" to t.colors.onBackground,
+        "onSurface" to t.colors.onSurface,
+    )
+    LazyColumn(modifier = Modifier.fillMaxSize().padding(t.spacing.md), verticalArrangement = Arrangement.spacedBy(t.spacing.sm)) {
+        items(colors) { (name, color) ->
+            Row(Modifier.height(40.dp)) {
+                Column(Modifier.size(40.dp).background(color)) {}
+                Text(name, modifier = Modifier.padding(start = 8.dp))
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/theme/ThemeTokens.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/theme/ThemeTokens.kt
@@ -1,0 +1,48 @@
+package com.mfme.kernel.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** Basic color set for the kernel theme. */
+data class ThemeColors(
+    val primary: Color,
+    val secondary: Color,
+    val background: Color,
+    val surface: Color,
+    val onPrimary: Color,
+    val onSecondary: Color,
+    val onBackground: Color,
+    val onSurface: Color,
+)
+
+/** Spacing tokens used throughout the UI. */
+data class ThemeSpacing(
+    val xs: Dp = 4.dp,
+    val sm: Dp = 8.dp,
+    val md: Dp = 16.dp,
+    val lg: Dp = 24.dp,
+)
+
+/** Corner radius tokens. */
+data class ThemeRadius(
+    val sm: Dp = 4.dp,
+    val md: Dp = 8.dp,
+    val lg: Dp = 12.dp,
+)
+
+/** Typography scale used by the kernel. */
+data class ThemeTypeScale(
+    val body: TextStyle,
+    val title: TextStyle,
+    val label: TextStyle,
+)
+
+/** Aggregated theme tokens. */
+data class ThemeTokens(
+    val colors: ThemeColors,
+    val spacing: ThemeSpacing = ThemeSpacing(),
+    val radius: ThemeRadius = ThemeRadius(),
+    val typeScale: ThemeTypeScale,
+)

--- a/android-app/app/src/test/java/com/mfme/kernel/ui/gestures/NoopGestureAdapterTest.kt
+++ b/android-app/app/src/test/java/com/mfme/kernel/ui/gestures/NoopGestureAdapterTest.kt
@@ -1,0 +1,44 @@
+package com.mfme.kernel.ui.gestures
+
+import com.mfme.kernel.data.Envelope
+import com.mfme.kernel.data.KernelRepository
+import com.mfme.kernel.data.SaveResult
+import com.mfme.kernel.ui.KernelViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private class FakeRepo : KernelRepository {
+    override fun observeReceipts(): Flow<List<com.mfme.kernel.data.telemetry.ReceiptEntity>> = flowOf(emptyList())
+    override fun observeEnvelopes(): Flow<List<Envelope>> = flowOf(emptyList())
+    override suspend fun saveEnvelope(env: Envelope): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromCamera(bytes: ByteArray, meta: Map<String, Any?>): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromMic(bytes: ByteArray, meta: Map<String, Any?>): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromFile(uri: android.net.Uri, meta: Map<String, Any?>): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromLocation(json: String): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromSensors(json: String): SaveResult = SaveResult.Success(0)
+    override suspend fun saveSmsOut(phone: String, body: String, at: java.time.Instant): SaveResult = SaveResult.Success(0)
+    override suspend fun ingestSmsIn(sender: String, body: String, at: java.time.Instant): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromShare(payload: com.mfme.kernel.adapters.share.SharePayload): SaveResult = SaveResult.Success(0)
+}
+
+class NoopGestureAdapterTest {
+    @Test
+    fun coalescesRapidMarks() = runTest {
+        val vm = KernelViewModel(FakeRepo())
+        var count = 0
+        val job = launch { vm.gestures.collect { count++ } }
+        var now = 0L
+        val adapter = NoopGestureAdapter(vm, windowMs = 300) { now }
+        adapter.on(GestureIntent.Mark)
+        adapter.on(GestureIntent.Mark)
+        assertEquals(1, count)
+        now += 400
+        adapter.on(GestureIntent.Mark)
+        assertEquals(2, count)
+        job.cancel()
+    }
+}

--- a/android-app/app/src/test/java/com/mfme/kernel/ui/log/LogSurfacePanelTest.kt
+++ b/android-app/app/src/test/java/com/mfme/kernel/ui/log/LogSurfacePanelTest.kt
@@ -1,0 +1,22 @@
+package com.mfme.kernel.ui.log
+
+import com.mfme.kernel.data.Envelope
+import com.mfme.kernel.data.telemetry.ReceiptEntity
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class LogSurfacePanelTest {
+    @Test
+    fun markdownPreviewHasEntries() {
+        val receipts = listOf(
+            ReceiptEntity(id = 1, ok = true, code = "ok", adapter = "a", tsUtcIso = "2023-01-01T00:00:00Z", envelopeId = null, envelopeSha256 = "e1", message = null, spanId = "s", receiptSha256 = "r1")
+        )
+        val envelopes = listOf(
+            Envelope(id = 1, sha256 = "e1", mime = "text/plain", text = "hello", filename = null, sourcePkgRef = "src", receivedAtUtc = Instant.EPOCH, metaJson = null)
+        )
+        val preview = buildMarkdownPreview(receipts, envelopes)
+        assertTrue(preview.contains("receipt ok"))
+        assertTrue(preview.contains("envelope e1"))
+    }
+}

--- a/android-app/app/src/test/java/com/mfme/kernel/ui/panels/PluginPanelHostTest.kt
+++ b/android-app/app/src/test/java/com/mfme/kernel/ui/panels/PluginPanelHostTest.kt
@@ -1,0 +1,44 @@
+package com.mfme.kernel.ui.panels
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mfme.kernel.ui.KernelViewModel
+import com.mfme.kernel.ui.theme.KernelTheme
+import com.mfme.kernel.data.KernelRepository
+import com.mfme.kernel.data.Envelope
+import com.mfme.kernel.data.SaveResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+
+private class FakeRepo : KernelRepository {
+    override fun observeReceipts(): Flow<List<com.mfme.kernel.data.telemetry.ReceiptEntity>> = flowOf(emptyList())
+    override fun observeEnvelopes(): Flow<List<Envelope>> = flowOf(emptyList())
+    override suspend fun saveEnvelope(env: Envelope): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromCamera(bytes: ByteArray, meta: Map<String, Any?>): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromMic(bytes: ByteArray, meta: Map<String, Any?>): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromFile(uri: android.net.Uri, meta: Map<String, Any?>): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromLocation(json: String): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromSensors(json: String): SaveResult = SaveResult.Success(0)
+    override suspend fun saveSmsOut(phone: String, body: String, at: java.time.Instant): SaveResult = SaveResult.Success(0)
+    override suspend fun ingestSmsIn(sender: String, body: String, at: java.time.Instant): SaveResult = SaveResult.Success(0)
+    override suspend fun saveFromShare(payload: com.mfme.kernel.adapters.share.SharePayload): SaveResult = SaveResult.Success(0)
+}
+
+class PluginPanelHostTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test
+    fun switchingTabsShowsDifferentPanel() {
+        val vm = KernelViewModel(FakeRepo())
+        compose.setContent {
+            registerBuiltinPanels(vm, devMode = false)
+            KernelTheme { PluginPanelHost() }
+        }
+        compose.onNodeWithText("Camera").assertExists()
+        compose.onNodeWithText("History").performClick()
+        compose.onNodeWithText("Receipts").assertExists()
+    }
+}

--- a/android-app/app/src/test/java/com/mfme/kernel/ui/theme/MinimalThemeTest.kt
+++ b/android-app/app/src/test/java/com/mfme/kernel/ui/theme/MinimalThemeTest.kt
@@ -1,0 +1,22 @@
+package com.mfme.kernel.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class MinimalThemeTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test
+    fun tokensExposeExpectedPrimaryColor() {
+        var color: Color? = null
+        compose.setContent {
+            KernelTheme(useDarkTheme = false) {
+                color = KernelTheme.tokens.colors.primary
+            }
+        }
+        assertEquals(Color(0xFF0061A4), color)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce KernelTheme with static tokens and preview screen
- add PluginPanelHost and registry to drive panel-based shell
- wire gesture framework, log surface, and operator lab stubs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aa37bcac8323b85eb9b08c8d5a13