### PR TITLE
Handle errors when observing history flows

### DIFF
--- a/android-app/app/src/main/java/com/mfme/kernel/ui/HistoryScreen.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/HistoryScreen.kt
@@ -24,6 +24,7 @@ import com.mfme.kernel.ui.theme.KernelTheme
 fun HistoryScreen(viewModel: KernelViewModel) {
     val receipts by viewModel.receipts.collectAsState()
     val envelopes by viewModel.envelopes.collectAsState()
+    val error by viewModel.error.collectAsState()
     var filter by remember { mutableStateOf(0) }
 
     val filtered = when (filter) {
@@ -38,6 +39,9 @@ fun HistoryScreen(viewModel: KernelViewModel) {
         modifier = Modifier.fillMaxSize().padding(tokens.spacing.md),
         verticalArrangement = Arrangement.spacedBy(tokens.spacing.sm)
     ) {
+        error?.let { msg ->
+            item { Text("Error loading history: $msg") }
+        }
         item {
             val tokens = KernelTheme.tokens
             Text("Receipts", style = tokens.typeScale.title)


### PR DESCRIPTION
## Summary
- Catch exceptions from receipt and envelope observers and expose error state in `KernelViewModel`
- Display a user-friendly message in `HistoryScreen` when history data fails to load

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c481d4a48323a195a308128a8dc5