### PR TITLE
Register panels once and pass stable list

### DIFF
--- a/android-app/app/src/debugUnitTest/java/com/mfme/kernel/ui/panels/PluginPanelHostTest.kt
+++ b/android-app/app/src/debugUnitTest/java/com/mfme/kernel/ui/panels/PluginPanelHostTest.kt
@@ -41,7 +41,8 @@ class PluginPanelHostTest {
         val vm = KernelViewModel(FakeRepo(), VaultConfig(context))
         compose.setContent {
             registerBuiltinPanels(vm, devMode = false)
-            KernelTheme { PluginPanelHost() }
+            val panels = PanelRegistry.all()
+            KernelTheme { PluginPanelHost(panels) }
         }
         compose.onNodeWithText("Camera").assertExists()
         compose.onNodeWithText("History").performClick()

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/KernelActivity.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/KernelActivity.kt
@@ -4,12 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mfme.kernel.ServiceLocator
+import com.mfme.kernel.ui.panels.PanelDescriptor
+import com.mfme.kernel.ui.panels.PanelRegistry
 import com.mfme.kernel.ui.panels.PluginPanelHost
 import com.mfme.kernel.ui.panels.registerBuiltinPanels
 import com.mfme.kernel.ui.theme.KernelTheme
@@ -33,8 +39,12 @@ fun KernelApp() {
         }
     })
 
-    registerBuiltinPanels(viewModel)
+    var panels by remember { mutableStateOf<List<PanelDescriptor>>(emptyList()) }
+    LaunchedEffect(Unit) {
+        registerBuiltinPanels(viewModel)
+        panels = PanelRegistry.all()
+    }
     KernelTheme {
-        PluginPanelHost()
+        PluginPanelHost(panels)
     }
 }

--- a/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PluginPanelHost.kt
+++ b/android-app/app/src/main/java/com/mfme/kernel/ui/panels/PluginPanelHost.kt
@@ -10,16 +10,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 
-/** Host composable that displays panels registered in [PanelRegistry]. */
+/** Host composable that displays the provided [panels]. */
 @Composable
-fun PluginPanelHost() {
-    val panels = remember { PanelRegistry.all() }
-    var activeId by rememberSaveable { mutableStateOf(panels.firstOrNull()?.id ?: "") }
+fun PluginPanelHost(panels: List<PanelDescriptor>) {
+    var activeId by rememberSaveable(panels) { mutableStateOf(panels.firstOrNull()?.id ?: "") }
     val active = panels.firstOrNull { it.id == activeId }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- Register builtin panels in a LaunchedEffect and expose them through state
- Update PluginPanelHost to accept a stable list of panels
- Adjust unit test to provide the panel list

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c48266488323b40d3c340c111bf1